### PR TITLE
feat(perf): 22 measurement algorithms + quality scorecard

### DIFF
--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -367,6 +367,18 @@ drift_pct = slope × (n-1) / mean × 100
 - **측정 대상**: `drop(DmaBuf)` = munmap + close
 - **사전 조건**: 타이밍 전에 alloc 완료
 - **용도**: deferred free pool로의 반환 지연, CMA 반환 비용
+- **Close/Alloc Ratio** (`perf::close_ratio`): paired alloc+close 측정으로 효율 비교
+  - 매 iteration에서 alloc과 close를 개별 타이밍
+  - `ratio = close_avg / alloc_avg`
+  - `<0.5` fast (deferred free), `0.5–2.0` balanced, `>2.0` expensive (CMA compaction)
+
+```
+[system]  perf::close_ratio
+           size  alloc  close  ratio  verdict
+             4K     12      3   0.25     fast
+            64K     45     15   0.33     fast
+             1M    250    800   3.20  expensive
+```
 
 ### 8.4 `bench_order_boundary`
 

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -1,0 +1,310 @@
+# Perf 서브커맨드 측정 알고리즘
+
+## 개요
+
+`dhp perf` 서브커맨드는 DMA heap 할당 성능을 정량적으로 측정한다.
+7개 벤치마크를 실행하며, 각 벤치마크는 동일한 통계 파이프라인을 거쳐 결과를 산출한다.
+
+```
+[samples] → sort → percentiles → variance → IQR filter → LatencyStats
+```
+
+---
+
+## 1. 타이밍 메커니즘
+
+### 클럭 소스
+
+```rust
+let start = Instant::now();
+// ... measured operation ...
+let elapsed = start.elapsed().as_micros() as u64;
+```
+
+- **`std::time::Instant`**: monotonic clock (`clock_gettime(CLOCK_MONOTONIC)`)
+- **해상도**: 플랫폼 의존 (Linux/Android: 일반적으로 1~100ns)
+- **저장 단위**: 마이크로초 (`u64`)
+- **오버플로우 안전**: `u64` 최대값 ~18.4 × 10^18 µs ≈ 584,542년
+
+### 측정 경계 (Timing Boundary)
+
+각 벤치마크는 서로 다른 구간을 측정한다:
+
+| 벤치마크 | 시작 | 종료 | 포함 연산 |
+|----------|------|------|-----------|
+| `alloc_only` | `heap.alloc()` 직전 | `alloc()` 반환 직후 | ioctl 호출만 |
+| `full_pipeline` | `heap.alloc()` 직전 | `sync_end(READ)` 직후 | alloc → mmap → sync(W) → memwrite → sync(R) |
+| `close` | `drop(buf)` 직전 | `drop(buf)` 직후 | munmap + close |
+| `order_boundary` | `heap.alloc()` 직전 | `alloc()` 반환 직후 | ioctl 호출만 (15개 사이즈) |
+| `pool_warmup` | `heap.alloc()` 직전 | `alloc()` 반환 직후 | cold vs warm 비교 |
+| `size_switch` | `heap.alloc()` 직전 | `alloc()` 반환 직후 | 사이즈 전환 영향 |
+| `internal_frag` | N/A | N/A | `llseek(SEEK_END)` 크기 비교 (타이밍 없음) |
+
+**주의**: `alloc_only`에서 `drop(buf)`는 타이밍 구간 **밖**에서 실행된다.
+`full_pipeline`에서 `drop(buf)`도 타이밍 구간 밖이다.
+`close`에서만 `drop(buf)`가 타이밍 구간 **안**에 있다.
+
+---
+
+## 2. 워밍업 (Warmup)
+
+```
+for _ in 0..warmup {
+    alloc → [pipeline] → drop    // 결과 폐기
+}
+for _ in 0..iterations {
+    measure()                    // 결과 수집
+}
+```
+
+- **목적**: 커널 페이지 풀, slab 캐시, TLB 프리밍
+- **기본값**: `--warmup 10` (CLI 인자로 조정 가능)
+- **메커니즘**: 워밍업 반복에서 alloc/free 사이클을 실행하여 커널이 deferred free pool을 채우도록 유도
+- **한계**: 워밍업이 충분한지 자동 검증하지 않음 (CV로 간접 확인 가능)
+
+---
+
+## 3. 통계 계산 (`compute_stats`)
+
+### 3.1 정렬
+
+```rust
+let mut sorted = samples.to_vec();
+sorted.sort_unstable();      // O(n log n), in-place 불안정 정렬
+```
+
+- 원본 배열을 보존하기 위해 복사 후 정렬
+- `sort_unstable()` 사용: 추가 메모리 할당 없음, 동일값 순서 보장 불필요
+
+### 3.2 평균 (Mean)
+
+```rust
+let mean_f = sum as f64 / count as f64;
+avg_us = mean_f.round() as u64;        // 반올림 (절삭 아님)
+```
+
+- **부동소수점 정밀도**: `f64` (53비트 가수부)로 정확한 평균 계산
+- **반올림**: `round()` 사용 — 이전 `sum / count` 정수 나눗셈의 절삭 오류 제거
+- **오버플로우**: `sum: u64`는 10^5 iterations × 10^9 µs = 10^14까지 안전 (`u64` 최대 1.8×10^19)
+
+### 3.3 분산 및 표준편차 (Variance / Standard Deviation)
+
+```rust
+// Two-pass algorithm
+let variance = sorted.iter()
+    .map(|&x| (x as f64 - mean_f).powi(2))
+    .sum::<f64>() / count as f64;
+let stddev = variance.sqrt();
+```
+
+**알고리즘 선택: Two-pass vs Welford's**
+
+| 방법 | 장점 | 단점 |
+|------|------|------|
+| **Two-pass** (채택) | 정수 데이터에 수치적으로 안정, 간단 | 두 번째 패스 필요 |
+| Welford's online | 단일 패스 | 부동소수점 누적 오류 가능 |
+
+- **모집단 분산** (N으로 나눔): 벤치마크 반복은 이론적 분포의 표본이 아니라 실제 측정의 전체 집합
+- N=100에서 모집단(N) vs 표본(N-1) 표준편차 차이: ~0.5% — 실질적 무의미
+
+### 3.4 변동계수 (Coefficient of Variation, CV)
+
+```rust
+cv_pct = stddev / mean * 100.0
+```
+
+- **의미**: 평균 대비 편차의 비율 (%)
+- **판단 기준**:
+  - CV < 5%: 매우 안정적 측정
+  - CV 5-15%: 양호
+  - CV > 15%: 노이즈 높음, `--iterations` 증가 권장
+  - CV > 30%: 외부 간섭 의심 (다른 프로세스, thermal throttling 등)
+
+### 3.5 백분위수 (Percentiles)
+
+```rust
+// Nearest-rank method (inclusive, NIST R-2)
+fn percentile(sorted: &[u64], p: u32) -> u64 {
+    let rank = ceil(p * n / 100);
+    sorted[rank - 1]
+}
+```
+
+**Nearest-rank 방식 선택 이유:**
+- 결과가 항상 실제 관측값 — 보간(interpolation) 없음
+- 정수 데이터에 적합: 보간 결과가 존재하지 않는 값을 생성하지 않음
+- `p99`가 실제로 관측된 worst-case에 가까운 값을 반환
+
+**분수 백분위수** (`p99.9`):
+
+```rust
+fn percentile_frac(sorted: &[u64], numer: u64, denom: u64) -> u64 {
+    let rank = ceil(numer * n / denom);
+    sorted[rank - 1]
+}
+```
+
+- p99.9 = `percentile_frac(sorted, 999, 1000)`
+- N=100 샘플에서 p99.9 = sorted[99] = 최대값 (rank = ceil(99.9) = 100)
+- N=1000 이상에서 의미 있는 분별력 제공
+
+**제공 백분위수:** p50 (중앙값), p95, p99, p99.9
+
+---
+
+## 4. IQR 이상치 탐지 (Outlier Detection)
+
+### 4.1 알고리즘: Tukey's Fence
+
+```
+Q1 = percentile(sorted, 25)
+Q3 = percentile(sorted, 75)
+IQR = Q3 - Q1
+
+lower_fence = Q1 - 1.5 × IQR
+upper_fence = Q3 + 1.5 × IQR
+
+outlier := sample < lower_fence OR sample > upper_fence
+```
+
+### 4.2 Trimmed Mean
+
+```rust
+trimmed_avg = mean(samples WHERE lower_fence ≤ sample ≤ upper_fence)
+outlier_count = count(samples WHERE sample IS outlier)
+```
+
+### 4.3 설계 결정
+
+| 결정 | 근거 |
+|------|------|
+| 1.5×IQR (표준) | 3×IQR은 너무 관대, 1×IQR은 너무 공격적 |
+| N < 4일 때 비활성 | IQR 계산에 최소 4개 샘플 필요 |
+| raw avg와 trimmed avg 모두 보고 | 사용자가 outlier 영향을 직접 비교 가능 |
+| 모집단 stddev는 trimmed 아님 | stddev는 전체 분포의 특성을 반영해야 함 |
+
+### 4.4 해석 가이드
+
+```
+[system]  perf::alloc_only (us)
+           size  min  avg  tavg  sd  p50  p95  p99  p99.9  max  out
+             4K    5   12     8   3    8   15   25     42   42    3
+```
+
+- `avg=12, tavg=8`: outlier 3개가 평균을 50% 끌어올림
+- `tavg`가 `p50`에 가까울수록 분포가 대칭적
+- `out > 0`이면 OS 스케줄러 jitter나 인터럽트 간섭이 존재
+
+---
+
+## 5. 벤치마크별 상세
+
+### 5.1 `bench_alloc_only`
+
+커널 `DMA_HEAP_IOCTL_ALLOC` 호출의 순수 지연시간.
+
+- **측정 대상**: ioctl 시스콜만 (mmap, sync 제외)
+- **사이즈**: `--sizes` (기본 4K, 64K, 1M)
+- **용도**: 힙 할당자 성능의 기준선
+
+### 5.2 `bench_full_pipeline`
+
+실제 사용 시나리오: 할당 → 매핑 → 쓰기 → 읽기 → 해제.
+
+- **측정 구간**: alloc → mmap → sync_start(W) → memwrite → sync_end(W) → sync_start(R) → sync_end(R)
+- **memwrite**: `write_bytes(ptr, 0xAA, size)` — 전체 버퍼 쓰기
+- **용도**: 캐시 유지보수 비용 포함한 end-to-end 지연
+
+### 5.3 `bench_close`
+
+버퍼 해제 경로 지연시간.
+
+- **측정 대상**: `drop(DmaBuf)` = munmap + close
+- **사전 조건**: 타이밍 전에 alloc 완료
+- **용도**: deferred free pool로의 반환 지연, CMA 반환 비용
+
+### 5.4 `bench_order_boundary`
+
+커널 buddy allocator의 order 경계에서 할당 비용 변화 측정.
+
+- **사이즈 범위**: 4K → 8M (15개 포인트, 64K 경계 집중)
+- **관찰 포인트**: `49152 (48K)` vs `65536 (64K)` — order 4 경계
+- **용도**: buddy allocator의 order 승격/분할 비용 시각화
+
+### 5.5 `bench_internal_frag`
+
+비정렬 요청 시 내부 단편화 비율.
+
+- **방법**: `llseek(fd, 0, SEEK_END)` — 커널이 실제 할당한 크기 반환
+- **사이즈**: 1, 4095, 4097, 65535, 65537, 100000 (의도적 비정렬)
+- **출력**: `frag% = (actual - requested) / requested × 100`
+- **용도**: 힙의 할당 그래뉼래리티(보통 4K) 확인
+
+### 5.6 `bench_pool_warmup`
+
+cold start vs warm state 할당 비용 비교.
+
+- **cold**: 처음 100회 alloc (pool 미충전 상태)
+- **warm**: 100회 alloc/free 사이클 후 100회 측정
+- **출력**: `cold_p50, cold_p95, warm_p50, warm_p95`
+- **용도**: 커널 deferred free pool의 효과 정량화
+
+### 5.7 `bench_size_switch`
+
+사이즈 전환이 할당 지연에 미치는 영향.
+
+- **3 phase**: 64K×500 → 4K×500 → 64K×500
+- **분석**: 각 phase의 처음 10회 vs 마지막 10회 p50 비교
+- **용도**: 사이즈별 pool이 분리되었는지, 전환 비용이 있는지 확인
+
+---
+
+## 6. JSON 출력 형식
+
+`LatencyStats` 구조체가 그대로 직렬화된다:
+
+```json
+{
+  "count": 100,
+  "min_us": 5,
+  "max_us": 42,
+  "avg_us": 12,
+  "stddev_us": 8,
+  "p50_us": 8,
+  "p95_us": 25,
+  "p99_us": 38,
+  "p99_9_us": 42,
+  "cv_pct": 66.7,
+  "trimmed_avg_us": 9,
+  "outlier_count": 3
+}
+```
+
+---
+
+## 7. 정밀도 한계 및 주의사항
+
+| 한계 | 영향 | 완화 방법 |
+|------|------|-----------|
+| 마이크로초 해상도 | fast op이 0µs로 측정될 수 있음 | `--iterations` 증가로 통계적 보상 |
+| OS 스케줄러 jitter | p99+ 값에 spike 발생 | IQR trimmed mean으로 분리 |
+| Thermal throttling | 긴 벤치마크에서 후반부 지연 증가 | CV 모니터링, 짧은 벤치마크 선호 |
+| `Instant` 오버헤드 | 매 측정마다 ~20ns 추가 | 마이크로초 단위에서 무시 가능 (<1%) |
+| 메모리 압박 | 대량 alloc 시 커널 경로 변경 | warmup으로 pool 안정화 |
+
+---
+
+## 8. 알고리즘 복잡도
+
+| 단계 | 시간 복잡도 | 공간 복잡도 |
+|------|-------------|-------------|
+| 수집 | O(n) | O(n) |
+| 정렬 | O(n log n) | O(1) in-place |
+| 합계/평균 | O(n) | O(1) |
+| 분산 (2nd pass) | O(n) | O(1) |
+| 백분위수 | O(1) per query | O(1) |
+| IQR trimmed mean | O(n) | O(1) |
+| **전체** | **O(n log n)** | **O(n)** |
+
+n = iterations (기본 100). 모든 통계 계산은 수집 + 정렬 이후 단일 패스로 완료 가능하며,
+현재 구현은 가독성을 위해 별도 패스를 사용한다 (성능 차이 무시 가능).

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -120,7 +120,21 @@ cv_pct = stddev / mean * 100.0
   - CV > 15%: 노이즈 높음, `--iterations` 증가 권장
   - CV > 30%: 외부 간섭 의심 (다른 프로세스, thermal throttling 등)
 
-### 3.5 백분위수 (Percentiles)
+### 3.5 자기상관 및 실효 샘플 수 (Autocorrelation & ESS)
+
+```
+r = cov(x[i], x[i+1]) / var(x)     // lag-1 autocorrelation
+ESS = N × (1 - r) / (1 + r)         // Kish's formula
+```
+
+- **r > 0**: 연속 샘플이 양의 상관 (pool caching, thermal drift)
+  - CI가 과소추정됨 — 실제 불확실성이 보고된 것보다 큼
+- **r ≈ 0**: 독립 샘플 (이상적)
+- **r < 0**: 교대 패턴 (alloc/free pool 진동)
+- **ESS**: 독립 샘플로 환산한 실효 수. `ESS << N`이면 CI에 `sqrt(N/ESS)` 보정 필요
+- `|r| > 0.1`일 때만 `perf::autocorr` 출력 (무의미한 노이즈 억제)
+
+### 3.6 백분위수 (Percentiles)
 
 ```rust
 // Nearest-rank method (inclusive, NIST R-2)
@@ -150,7 +164,7 @@ fn percentile_frac(sorted: &[u64], numer: u64, denom: u64) -> u64 {
 
 **제공 백분위수:** p50 (중앙값), p95, p99, p99.9
 
-### 3.6 백분위수 신뢰구간 (Percentile CI)
+### 3.7 백분위수 신뢰구간 (Percentile CI)
 
 p99에 대한 95% 비모수 신뢰구간 (binomial order statistics):
 

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -241,17 +241,58 @@ ci95_us = ceil(1.96 × stddev / sqrt(n))
 
 ---
 
-## 6. 벤치마크별 상세
+## 6. Size-Latency 선형 회귀 분석
 
-### 6.1 `bench_alloc_only`
+### 6.1 알고리즘: Ordinary Least Squares (OLS)
+
+`alloc_only` 벤치마크 종료 후, (size, avg_us) 쌍에 대해 선형 모델을 적합:
+
+```
+latency_us = base_us + slope_us_per_byte × size_bytes
+```
+
+**최소제곱법:**
+
+```
+slope = Σ(xi - x̄)(yi - ȳ) / Σ(xi - x̄)²
+intercept = ȳ - slope × x̄
+R² = 1 - SS_res / SS_tot
+```
+
+### 6.2 출력 필드
+
+| 필드 | 의미 |
+|------|------|
+| `base_us` | 사이즈 무관 고정 비용 (y절편) — ioctl 오버헤드, 잠금 경합 등 |
+| `us/KB` | KB당 추가 비용 (slope × 1024) — 페이지 할당, zeroing 비용 |
+| `R²` | 결정계수 (0~1). 1에 가까울수록 사이즈-지연 관계가 선형적 |
+
+### 6.3 해석 가이드
+
+```
+[system]  perf::alloc_model  base_us: 5.2  us/KB: 0.045  R²: 0.987
+```
+
+- **R² > 0.95**: 강한 선형 관계 — 지연은 사이즈에 비례
+- **R² < 0.5**: 비선형 — buddy allocator order 경계, pool hit/miss 등의 영향
+- **base_us 높음**: 고정 오버헤드가 큼 (잠금 경합, slab 경로)
+- **us/KB ≈ 0**: 사이즈 무관 할당자 (pool 기반, 사전 할당)
+- 최소 2개 사이즈 필요. 3개 이상에서 R²가 의미 있음
+
+---
+
+## 7. 벤치마크별 상세
+
+### 7.1 `bench_alloc_only`
 
 커널 `DMA_HEAP_IOCTL_ALLOC` 호출의 순수 지연시간.
 
 - **측정 대상**: ioctl 시스콜만 (mmap, sync 제외)
 - **사이즈**: `--sizes` (기본 4K, 64K, 1M)
 - **용도**: 힙 할당자 성능의 기준선
+- **회귀 분석**: 테이블 후 `perf::alloc_model` 라인으로 size-latency 모델 출력
 
-### 6.2 `bench_full_pipeline`
+### 7.2 `bench_full_pipeline`
 
 실제 사용 시나리오: 할당 → 매핑 → 쓰기 → 읽기 → 해제.
 
@@ -259,7 +300,7 @@ ci95_us = ceil(1.96 × stddev / sqrt(n))
 - **memwrite**: `write_bytes(ptr, 0xAA, size)` — 전체 버퍼 쓰기
 - **용도**: 캐시 유지보수 비용 포함한 end-to-end 지연
 
-### 6.3 `bench_close`
+### 7.3 `bench_close`
 
 버퍼 해제 경로 지연시간.
 
@@ -267,7 +308,7 @@ ci95_us = ceil(1.96 × stddev / sqrt(n))
 - **사전 조건**: 타이밍 전에 alloc 완료
 - **용도**: deferred free pool로의 반환 지연, CMA 반환 비용
 
-### 6.4 `bench_order_boundary`
+### 7.4 `bench_order_boundary`
 
 커널 buddy allocator의 order 경계에서 할당 비용 변화 측정.
 
@@ -275,7 +316,7 @@ ci95_us = ceil(1.96 × stddev / sqrt(n))
 - **관찰 포인트**: `49152 (48K)` vs `65536 (64K)` — order 4 경계
 - **용도**: buddy allocator의 order 승격/분할 비용 시각화
 
-### 6.5 `bench_internal_frag`
+### 7.5 `bench_internal_frag`
 
 비정렬 요청 시 내부 단편화 비율.
 
@@ -284,7 +325,7 @@ ci95_us = ceil(1.96 × stddev / sqrt(n))
 - **출력**: `frag% = (actual - requested) / requested × 100`
 - **용도**: 힙의 할당 그래뉼래리티(보통 4K) 확인
 
-### 6.6 `bench_pool_warmup`
+### 7.6 `bench_pool_warmup`
 
 cold start vs warm state 할당 비용 비교.
 
@@ -293,7 +334,7 @@ cold start vs warm state 할당 비용 비교.
 - **출력**: `cold_p50, cold_p95, warm_p50, warm_p95`
 - **용도**: 커널 deferred free pool의 효과 정량화
 
-### 6.7 `bench_size_switch`
+### 7.7 `bench_size_switch`
 
 사이즈 전환이 할당 지연에 미치는 영향.
 
@@ -303,7 +344,7 @@ cold start vs warm state 할당 비용 비교.
 
 ---
 
-## 7. JSON 출력 형식
+## 8. JSON 출력 형식
 
 `LatencyStats` 구조체가 그대로 직렬화된다:
 
@@ -328,7 +369,7 @@ cold start vs warm state 할당 비용 비교.
 
 ---
 
-## 8. 정밀도 한계 및 주의사항
+## 9. 정밀도 한계 및 주의사항
 
 | 한계 | 영향 | 완화 방법 |
 |------|------|-----------|
@@ -340,7 +381,7 @@ cold start vs warm state 할당 비용 비교.
 
 ---
 
-## 9. 알고리즘 복잡도
+## 10. 알고리즘 복잡도
 
 | 단계 | 시간 복잡도 | 공간 복잡도 |
 |------|-------------|-------------|

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -60,7 +60,7 @@ for _ in 0..iterations {
 - **목적**: 커널 페이지 풀, slab 캐시, TLB 프리밍
 - **기본값**: `--warmup 10` (CLI 인자로 조정 가능)
 - **메커니즘**: 워밍업 반복에서 alloc/free 사이클을 실행하여 커널이 deferred free pool을 채우도록 유도
-- **한계**: 워밍업이 충분한지 자동 검증하지 않음 (CV로 간접 확인 가능)
+- **자동 검증**: `warmup_sufficient()` — 측정 시작 10% vs 나머지 90% Welch's t-test로 cold start 잔류 감지
 
 ---
 
@@ -180,6 +180,18 @@ upper = sorted[min(n, ceil(rank + 1.96 × se_rank)) - 1]
 - **테이블 표시**: `p99[ci95]` 컬럼 (예: `38[32-45]`)
 - **SLA/SLO 활용**: "p99 ≤ 45µs with 95% confidence"
 
+### 3.8 Median Absolute Deviation (MAD)
+
+```
+MAD = median(|x_i - median(x)|)
+```
+
+- **Breakdown point**: 50% (stddev의 0% 대비 극도로 robust)
+- 전체 데이터의 50%가 오염되어도 MAD는 정확함
+- `MAD = 0, stddev > 0` → outlier만 산포에 기여 (핵심 분포는 일정)
+- **MADN** = `MAD × 1.4826` — 정규분포 하에서 stddev의 일관 추정량
+- `MADN << stddev` → heavy tail 존재
+
 ---
 
 ## 4. IQR 이상치 탐지 (Outlier Detection)
@@ -227,9 +239,63 @@ outlier_count = count(samples WHERE sample IS outlier)
 
 ---
 
-## 5. Throughput 및 신뢰구간 (Throughput & CI)
+## 5. 분포 형태 분석 (Distribution Shape)
 
-### 5.1 Throughput (ops/sec)
+### 5.1 Skewness (왜도) & Excess Kurtosis (초과 첨도)
+
+```
+skewness = E[(x - mean)³] / stddev³
+kurtosis = E[(x - mean)⁴] / stddev⁴ - 3
+```
+
+| 값 | 의미 |
+|----|------|
+| skew > 2.0 | heavy right tail — 극단적 지연 스파이크 존재 |
+| skew > 0.5 | right-skewed — 일반적 지연 분포 |
+| skew ≈ 0 | symmetric — 대칭 분포 |
+| skew < -0.5 | left-skewed — 비정상 (드묾) |
+| kurtosis > 0 | leptokurtic — 정규분포보다 꼬리가 두꺼움 |
+| kurtosis < 0 | platykurtic — 정규분포보다 꼬리가 얇음 |
+
+### 5.2 Shannon Entropy (정보 엔트로피)
+
+```
+H = -Σ p_i × log2(p_i)
+H_normalized = H / log2(k)    // [0, 1] 범위로 정규화
+```
+
+히스토그램 기반 (Sturges' rule 버킷). 정규화 엔트로피:
+
+| 값 | 의미 |
+|----|------|
+| < 0.3 | deterministic — 할당 지연이 매우 예측 가능 |
+| 0.3–0.7 | moderate — 보통 수준의 변동 |
+| > 0.7 | unpredictable — 높은 불확실성, 외부 간섭 의심 |
+
+힙 간 비교: "system: H=0.2 (deterministic) vs reserved: H=0.8 (unpredictable)"
+
+### 5.3 Bimodal Detection (이중 모드 감지)
+
+히스토그램 피크 탐지 + valley 깊이 검사:
+
+1. Sturges' rule로 버킷 생성 (최소 8개)
+2. 로컬 최대값(양쪽보다 큰 버킷) 탐지
+3. 상위 2개 피크 사이의 valley(최소 카운트) 확인
+4. `valley_count / min(peak1, peak2) < 0.5` → bimodal 선언
+
+```
+[system]  perf::bimodal@4K  fast: 8us (75%)  slow: 45us  valley: 12%
+```
+
+- **fast mode**: pool hit (deferred free에서 즉시 반환)
+- **slow mode**: buddy allocator fallback
+- `valley` 값이 낮을수록 두 모드가 명확히 분리
+
+---
+
+## 6. Throughput 및 신뢰구간 (Throughput & CI)
+
+### 6.1 Throughput (ops/sec)
 
 ```
 throughput_ops = round(1,000,000 / mean_us)
@@ -240,7 +306,7 @@ throughput_ops = round(1,000,000 / mean_us)
 - `mean_us = 0`일 때 `throughput_ops = 0` (mock 백엔드 fast path)
 - **용도**: 힙 간 성능 비교 ("system: 50Kops/s vs reserved: 30Kops/s")
 
-### 5.2 95% 신뢰구간 (Confidence Interval)
+### 6.2 95% 신뢰구간 (Confidence Interval)
 
 ```
 ci95_us = ceil(1.96 × stddev / sqrt(n))
@@ -259,7 +325,7 @@ ci95_us = ceil(1.96 × stddev / sqrt(n))
 | ci95 = avg × 5~20% | 보통 | `--iterations` 증가 고려 |
 | ci95 > avg × 20% | 부정확 | `--iterations` 증가 필수 또는 외부 간섭 확인 |
 
-### 5.3 테이블 예시
+### 6.3 테이블 예시
 
 ```
 [system]  perf::alloc_only (us)
@@ -271,9 +337,9 @@ ci95_us = ceil(1.96 × stddev / sqrt(n))
 
 ---
 
-## 6. Size-Latency 선형 회귀 분석
+## 7. Size-Latency 선형 회귀 분석
 
-### 6.1 알고리즘: Ordinary Least Squares (OLS)
+### 7.1 알고리즘: Ordinary Least Squares (OLS)
 
 `alloc_only` 벤치마크 종료 후, (size, avg_us) 쌍에 대해 선형 모델을 적합:
 
@@ -289,7 +355,7 @@ intercept = ȳ - slope × x̄
 R² = 1 - SS_res / SS_tot
 ```
 
-### 6.2 출력 필드
+### 7.2 출력 필드
 
 | 필드 | 의미 |
 |------|------|
@@ -297,7 +363,7 @@ R² = 1 - SS_res / SS_tot
 | `us/KB` | KB당 추가 비용 (slope × 1024) — 페이지 할당, zeroing 비용 |
 | `R²` | 결정계수 (0~1). 1에 가까울수록 사이즈-지연 관계가 선형적 |
 
-### 6.3 해석 가이드
+### 7.3 해석 가이드
 
 ```
 [system]  perf::alloc_model  base_us: 5.2  us/KB: 0.045  R²: 0.987
@@ -311,11 +377,11 @@ R² = 1 - SS_res / SS_tot
 
 ---
 
-## 7. Drift Detection (시간적 편향 감지)
+## 8. Drift Detection (시간적 편향 감지)
 
 측정 도중 지연시간이 체계적으로 변하는지 자동 감지한다.
 
-### 7.1 알고리즘
+### 8.1 알고리즘
 
 샘플 인덱스 `i`와 지연시간 `latency[i]`에 대해 선형 회귀:
 
@@ -326,7 +392,7 @@ drift_pct = slope × (n-1) / mean × 100
 
 추가로 전반부/후반부 평균을 비교하여 직관적 해석을 제공한다.
 
-### 7.2 출력 조건
+### 8.2 출력 조건
 
 `|drift_pct| > 10%`일 때만 경고를 출력한다:
 
@@ -340,7 +406,7 @@ drift_pct = slope × (n-1) / mean × 100
 | < -10% | 후반부가 빠름 (improving) | Warmup 부족, JIT/pool이 아직 안정화 안 됨 |
 | -10% ~ +10% | 안정 | 정상적 측정 |
 
-### 7.3 설계 결정
+### 8.3 설계 결정
 
 | 결정 | 근거 |
 |------|------|
@@ -351,9 +417,9 @@ drift_pct = slope × (n-1) / mean × 100
 
 ---
 
-## 8. 벤치마크별 상세
+## 9. 벤치마크별 상세
 
-### 8.1 `bench_alloc_only`
+### 9.1 `bench_alloc_only`
 
 커널 `DMA_HEAP_IOCTL_ALLOC` 호출의 순수 지연시간.
 
@@ -374,7 +440,7 @@ drift_pct = slope × (n-1) / mean × 100
              1M       4    4.8   4096
 ```
 
-### 8.2 `bench_full_pipeline`
+### 9.2 `bench_full_pipeline`
 
 실제 사용 시나리오: 할당 → 매핑 → 쓰기 → 읽기 → 해제.
 
@@ -402,7 +468,7 @@ drift_pct = slope × (n-1) / mean × 100
 - 타이머 오버헤드: `Instant::now()` 5회 × ~20ns = ~100ns/iter (<1% at µs scale)
 - `sync_w`에 `write_bytes`가 포함됨 — 캐시 flush와 메모리 쓰기가 결합된 실제 비용
 
-### 8.3 `bench_close`
+### 9.3 `bench_close`
 
 버퍼 해제 경로 지연시간.
 
@@ -422,7 +488,7 @@ drift_pct = slope × (n-1) / mean × 100
              1M    250    800   3.20  expensive
 ```
 
-### 8.4 `bench_order_boundary`
+### 9.4 `bench_order_boundary`
 
 커널 buddy allocator의 order 경계에서 할당 비용 변화 측정.
 
@@ -438,7 +504,14 @@ drift_pct = slope × (n-1) / mean × 100
 [system]  perf::order_step (order 4)  from: 48K  to: 64K   avg: 12→18us  +%: 50.0
 ```
 
-### 8.5 `bench_internal_frag`
+- **Inversion Detection**: 큰 사이즈가 오히려 빠른 역전 현상 감지 (>10% 감소)
+  - size-class 풀링이나 할당자 fast-path 최적화를 나타냄
+
+```
+[system]  perf::inversion  larger: 64K  smaller: 48K  avg: 20→10us  -%: 50.0
+```
+
+### 9.5 `bench_internal_frag`
 
 비정렬 요청 시 내부 단편화 비율.
 
@@ -447,7 +520,7 @@ drift_pct = slope × (n-1) / mean × 100
 - **출력**: `frag% = (actual - requested) / requested × 100`
 - **용도**: 힙의 할당 그래뉼래리티(보통 4K) 확인
 
-### 8.6 `bench_pool_warmup`
+### 9.6 `bench_pool_warmup`
 
 cold start vs warm state 할당 비용 비교.
 
@@ -466,7 +539,7 @@ cold start vs warm state 할당 비용 비교.
 [system]  perf::pool_effect  t: 8.32  d: 1.85  sig: ***  effect: large
 ```
 
-### 8.7 `bench_size_switch`
+### 9.7 `bench_size_switch`
 
 사이즈 전환이 할당 지연에 미치는 영향.
 
@@ -489,9 +562,9 @@ cold start vs warm state 할당 비용 비교.
 
 ---
 
-## 9. JSON 출력 형식
+## 10. JSON 출력 형식
 
-`LatencyStats` 구조체가 그대로 직렬화된다:
+### 10.1 `LatencyStats`
 
 ```json
 {
@@ -508,17 +581,41 @@ cold start vs warm state 할당 비용 비교.
   "trimmed_avg_us": 9,
   "outlier_count": 3,
   "throughput_ops": 83333,
-  "ci95_us": 2
+  "ci95_us": 2,
+  "mad_us": 5
+}
+```
+
+### 10.2 `PerfAnalysis` (alloc_only 분석 결과)
+
+`--output` 사용 시 `stages[0].details.analysis`에 포함:
+
+```json
+{
+  "stats": [
+    {"size": 4096, "latency": { /* LatencyStats */ }},
+    {"size": 65536, "latency": { /* LatencyStats */ }}
+  ],
+  "regression": {
+    "intercept_us": 5.2,
+    "slope_us_per_byte": 0.001,
+    "r_squared": 0.99
+  },
+  "quality_score": 90,
+  "quality_rating": "EXCELLENT",
+  "drift_pct": 0.0,
+  "autocorr_r": 0.05,
+  "ess": 95.2
 }
 ```
 
 ---
 
-## 10. Measurement Quality Scorecard
+## 11. Measurement Quality Scorecard
 
-`bench_alloc_only` 완료 후 4개 차원의 진단 신호를 종합한 품질 점수를 출력한다.
+`bench_alloc_only` 완료 후 5개 차원의 진단 신호를 종합한 품질 점수를 출력한다.
 
-### 10.1 채점 체계 (5차원 × 20점)
+### 11.1 채점 체계 (5차원 × 20점)
 
 | 차원 | 신호 | 20점 | 16점 | 8점 | 4점 | 0점 |
 |------|------|------|------|-----|-----|-----|
@@ -530,7 +627,7 @@ cold start vs warm state 할당 비용 비교.
 
 **등급**: >=90 EXCELLENT, >=75 GOOD, >=50 FAIR, <50 NOISY
 
-### 10.2 CI Convergence 분석
+### 11.2 CI Convergence 분석
 
 N/4, N/2, 3N/4, N 시점에서 CI 폭을 표시하여 수렴 속도를 시각화:
 
@@ -546,7 +643,7 @@ N/4, N/2, 3N/4, N 시점에서 CI 폭을 표시하여 수렴 속도를 시각화
 CI가 후반부에서 거의 줄지 않으면 (`±4 → ±3`) 반복 횟수 충분.
 여전히 빠르게 줄고 있으면 (`±8 → ±3`) `--iterations` 증가 권장.
 
-### 10.3 출력 예시
+### 11.3 출력 예시
 
 ```
 [system]  perf::quality  score: 90/100  rating: EXCELLENT
@@ -578,11 +675,22 @@ CI가 후반부에서 거의 줄지 않으면 (`±4 → ±3`) 반복 횟수 충�
 |------|-------------|-------------|
 | 수집 | O(n) | O(n) |
 | 정렬 | O(n log n) | O(1) in-place |
-| 합계/평균 | O(n) | O(1) |
-| 분산 (2nd pass) | O(n) | O(1) |
-| 백분위수 | O(1) per query | O(1) |
+| 합계/평균/분산 | O(n) | O(1) |
+| MAD (sort deviations) | O(n log n) | O(n) |
+| 백분위수 / percentile CI | O(1) per query | O(1) |
 | IQR trimmed mean | O(n) | O(1) |
+| Autocorrelation | O(n) | O(1) |
+| Drift detection | O(n) | O(1) |
+| Bimodal detection | O(n) | O(k) |
+| Skewness / kurtosis | O(n) | O(1) |
+| Shannon entropy | O(n) | O(k) |
+| Linear regression | O(m) | O(1) |
+| Order step / inversion | O(m) | O(m) |
+| Welch's t-test | O(n) | O(1) |
+| Warmup sufficiency | O(n) | O(1) |
+| CI convergence | O(n) | O(1) |
+| Quality scorecard | O(m) | O(1) |
 | **전체** | **O(n log n)** | **O(n)** |
 
-n = iterations (기본 100). 모든 통계 계산은 수집 + 정렬 이후 단일 패스로 완료 가능하며,
-현재 구현은 가독성을 위해 별도 패스를 사용한다 (성능 차이 무시 가능).
+n = iterations (기본 100), m = sizes (기본 3), k = histogram bins (Sturges).
+모든 통계 계산은 수집 + 정렬 이후 선형 시간에 완료된다.

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -355,6 +355,14 @@ drift_pct = slope × (n-1) / mean × 100
 - **사이즈 범위**: 4K → 8M (15개 포인트, 64K 경계 집중)
 - **관찰 포인트**: `49152 (48K)` vs `65536 (64K)` — order 4 경계
 - **용도**: buddy allocator의 order 승격/분할 비용 시각화
+- **Step Detection**: 인접 사이즈 간 >20% 증가 시 `perf::order_step` 출력
+  - `order N`: buddy allocator order (`ceil(log2(pages))`)
+  - 크기순이 아닌 증가폭순으로 정렬 — 가장 큰 bottleneck 먼저 표시
+
+```
+[system]  perf::order_step (order 5)  from: 64K  to: 128K  avg: 15→25us  +%: 66.7
+[system]  perf::order_step (order 4)  from: 48K  to: 64K   avg: 12→18us  +%: 50.0
+```
 
 ### 8.5 `bench_internal_frag`
 

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -488,7 +488,38 @@ cold start vs warm state 할당 비용 비교.
 
 ---
 
-## 10. 정밀도 한계 및 주의사항
+## 10. Measurement Quality Scorecard
+
+`bench_alloc_only` 완료 후 4개 차원의 진단 신호를 종합한 품질 점수를 출력한다.
+
+### 10.1 채점 체계
+
+| 차원 | 신호 | 25점 | 20점 | 10점 | 5점 | 0점 |
+|------|------|------|------|------|-----|-----|
+| Stability | max CV (%) | <5 | <10 | <20 | <30 | >=30 |
+| Precision | max CI/avg (%) | <3 | <10 | <20 | - | >=20 |
+| Cleanliness | outlier rate (%) | <1 | <5 | <10 | - | >=10 |
+| Stationarity | \|drift\| (%) | <5 | <10 | - | <20 | >=20 |
+
+**등급**: >=90 EXCELLENT, >=75 GOOD, >=50 FAIR, <50 NOISY
+
+### 10.2 출력 예시
+
+```
+[system]  perf::quality  score: 90/100  rating: EXCELLENT
+```
+
+점수가 낮은 차원에 대해 개선 권고를 출력:
+
+```
+[system]  perf::quality  score: 55/100  rating: FAIR
+[system]  perf::quality  stability=10/25  hint: cv>10%: increase --iterations or reduce load
+[system]  perf::quality  stationarity=5/25  hint: drift>10%: increase --warmup or shorten test
+```
+
+---
+
+## 12. 정밀도 한계 및 주의사항
 
 | 한계 | 영향 | 완화 방법 |
 |------|------|-----------|
@@ -500,7 +531,7 @@ cold start vs warm state 할당 비용 비교.
 
 ---
 
-## 11. 알고리즘 복잡도
+## 13. 알고리즘 복잡도
 
 | 단계 | 시간 복잡도 | 공간 복잡도 |
 |------|-------------|-------------|

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -347,6 +347,18 @@ drift_pct = slope × (n-1) / mean × 100
 - **사이즈**: `--sizes` (기본 4K, 64K, 1M)
 - **용도**: 힙 할당자 성능의 기준선
 - **회귀 분석**: 테이블 후 `perf::alloc_model` 라인으로 size-latency 모델 출력
+- **Scaling Efficiency** (`perf::scaling`): 사이즈별 throughput 유지율 + bandwidth
+  - `eff%`: 최소 사이즈 throughput 대비 비율 (100% = 동일)
+  - `MB/s`: `throughput * size` — 실제 메모리 대역폭
+  - 이상적 할당자: eff% 일정, MB/s는 사이즈에 비례
+
+```
+[system]  perf::scaling
+           size  Kops/s  eff%    MB/s
+             4K      83  100.0    332
+            64K      22   26.5   1408
+             1M       4    4.8   4096
+```
 
 ### 8.2 `bench_full_pipeline`
 

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -518,29 +518,44 @@ cold start vs warm state 할당 비용 비교.
 
 `bench_alloc_only` 완료 후 4개 차원의 진단 신호를 종합한 품질 점수를 출력한다.
 
-### 10.1 채점 체계
+### 10.1 채점 체계 (5차원 × 20점)
 
-| 차원 | 신호 | 25점 | 20점 | 10점 | 5점 | 0점 |
-|------|------|------|------|------|-----|-----|
+| 차원 | 신호 | 20점 | 16점 | 8점 | 4점 | 0점 |
+|------|------|------|------|-----|-----|-----|
 | Stability | max CV (%) | <5 | <10 | <20 | <30 | >=30 |
 | Precision | max CI/avg (%) | <3 | <10 | <20 | - | >=20 |
 | Cleanliness | outlier rate (%) | <1 | <5 | <10 | - | >=10 |
 | Stationarity | \|drift\| (%) | <5 | <10 | - | <20 | >=20 |
+| Warmup | head/tail t-test | pass | - | - | - | fail |
 
 **등급**: >=90 EXCELLENT, >=75 GOOD, >=50 FAIR, <50 NOISY
 
-### 10.2 출력 예시
+### 10.2 CI Convergence 분석
+
+N/4, N/2, 3N/4, N 시점에서 CI 폭을 표시하여 수렴 속도를 시각화:
+
+```
+[system]  perf::ci_convergence (us)
+              N  avg  ci95
+             25   12   ±8
+             50   11   ±5
+             75   11   ±4
+            100   11   ±3
+```
+
+CI가 후반부에서 거의 줄지 않으면 (`±4 → ±3`) 반복 횟수 충분.
+여전히 빠르게 줄고 있으면 (`±8 → ±3`) `--iterations` 증가 권장.
+
+### 10.3 출력 예시
 
 ```
 [system]  perf::quality  score: 90/100  rating: EXCELLENT
 ```
 
-점수가 낮은 차원에 대해 개선 권고를 출력:
-
 ```
-[system]  perf::quality  score: 55/100  rating: FAIR
-[system]  perf::quality  stability=10/25  hint: cv>10%: increase --iterations or reduce load
-[system]  perf::quality  stationarity=5/25  hint: drift>10%: increase --warmup or shorten test
+[system]  perf::quality  score: 52/100  rating: FAIR
+[system]  perf::quality  stability=8/20  hint: cv>10%: increase --iterations or reduce load
+[system]  perf::quality  warmup=0/20  hint: warmup insufficient: increase --warmup
 ```
 
 ---

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -281,9 +281,49 @@ R² = 1 - SS_res / SS_tot
 
 ---
 
-## 7. 벤치마크별 상세
+## 7. Drift Detection (시간적 편향 감지)
 
-### 7.1 `bench_alloc_only`
+측정 도중 지연시간이 체계적으로 변하는지 자동 감지한다.
+
+### 7.1 알고리즘
+
+샘플 인덱스 `i`와 지연시간 `latency[i]`에 대해 선형 회귀:
+
+```
+slope = Σ(i - ī)(y_i - ȳ) / Σ(i - ī)²
+drift_pct = slope × (n-1) / mean × 100
+```
+
+추가로 전반부/후반부 평균을 비교하여 직관적 해석을 제공한다.
+
+### 7.2 출력 조건
+
+`|drift_pct| > 10%`일 때만 경고를 출력한다:
+
+```
+[system]  perf::drift_warn (degrading)  drift: +25.3%  1st_half: 45  2nd_half: 58
+```
+
+| drift_pct | 의미 | 원인 |
+|-----------|------|------|
+| > +10% | 후반부가 느림 (degrading) | Thermal throttling, 메모리 압박 증가 |
+| < -10% | 후반부가 빠름 (improving) | Warmup 부족, JIT/pool이 아직 안정화 안 됨 |
+| -10% ~ +10% | 안정 | 정상적 측정 |
+
+### 7.3 설계 결정
+
+| 결정 | 근거 |
+|------|------|
+| 마지막(가장 큰) 사이즈만 분석 | 큰 할당이 thermal/pressure 영향에 가장 민감 |
+| 임계값 10% | 5% 미만은 통계적 노이즈, 10% 이상은 체계적 편향 |
+| 최소 10 샘플 | 그 이하에서는 회귀 slope가 불안정 |
+| 경고만 출력 (자동 보정 없음) | 사용자가 원인 판단하여 `--warmup`/`--iterations` 조정 |
+
+---
+
+## 8. 벤치마크별 상세
+
+### 8.1 `bench_alloc_only`
 
 커널 `DMA_HEAP_IOCTL_ALLOC` 호출의 순수 지연시간.
 
@@ -292,7 +332,7 @@ R² = 1 - SS_res / SS_tot
 - **용도**: 힙 할당자 성능의 기준선
 - **회귀 분석**: 테이블 후 `perf::alloc_model` 라인으로 size-latency 모델 출력
 
-### 7.2 `bench_full_pipeline`
+### 8.2 `bench_full_pipeline`
 
 실제 사용 시나리오: 할당 → 매핑 → 쓰기 → 읽기 → 해제.
 
@@ -300,7 +340,7 @@ R² = 1 - SS_res / SS_tot
 - **memwrite**: `write_bytes(ptr, 0xAA, size)` — 전체 버퍼 쓰기
 - **용도**: 캐시 유지보수 비용 포함한 end-to-end 지연
 
-### 7.3 `bench_close`
+### 8.3 `bench_close`
 
 버퍼 해제 경로 지연시간.
 
@@ -308,7 +348,7 @@ R² = 1 - SS_res / SS_tot
 - **사전 조건**: 타이밍 전에 alloc 완료
 - **용도**: deferred free pool로의 반환 지연, CMA 반환 비용
 
-### 7.4 `bench_order_boundary`
+### 8.4 `bench_order_boundary`
 
 커널 buddy allocator의 order 경계에서 할당 비용 변화 측정.
 
@@ -316,7 +356,7 @@ R² = 1 - SS_res / SS_tot
 - **관찰 포인트**: `49152 (48K)` vs `65536 (64K)` — order 4 경계
 - **용도**: buddy allocator의 order 승격/분할 비용 시각화
 
-### 7.5 `bench_internal_frag`
+### 8.5 `bench_internal_frag`
 
 비정렬 요청 시 내부 단편화 비율.
 
@@ -325,7 +365,7 @@ R² = 1 - SS_res / SS_tot
 - **출력**: `frag% = (actual - requested) / requested × 100`
 - **용도**: 힙의 할당 그래뉼래리티(보통 4K) 확인
 
-### 7.6 `bench_pool_warmup`
+### 8.6 `bench_pool_warmup`
 
 cold start vs warm state 할당 비용 비교.
 
@@ -334,7 +374,7 @@ cold start vs warm state 할당 비용 비교.
 - **출력**: `cold_p50, cold_p95, warm_p50, warm_p95`
 - **용도**: 커널 deferred free pool의 효과 정량화
 
-### 7.7 `bench_size_switch`
+### 8.7 `bench_size_switch`
 
 사이즈 전환이 할당 지연에 미치는 영향.
 
@@ -344,7 +384,7 @@ cold start vs warm state 할당 비용 비교.
 
 ---
 
-## 8. JSON 출력 형식
+## 9. JSON 출력 형식
 
 `LatencyStats` 구조체가 그대로 직렬화된다:
 
@@ -369,7 +409,7 @@ cold start vs warm state 할당 비용 비교.
 
 ---
 
-## 9. 정밀도 한계 및 주의사항
+## 10. 정밀도 한계 및 주의사항
 
 | 한계 | 영향 | 완화 방법 |
 |------|------|-----------|
@@ -381,7 +421,7 @@ cold start vs warm state 할당 비용 비교.
 
 ---
 
-## 10. 알고리즘 복잡도
+## 11. 알고리즘 복잡도
 
 | 단계 | 시간 복잡도 | 공간 복잡도 |
 |------|-------------|-------------|

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -197,9 +197,53 @@ outlier_count = count(samples WHERE sample IS outlier)
 
 ---
 
-## 5. 벤치마크별 상세
+## 5. Throughput 및 신뢰구간 (Throughput & CI)
 
-### 5.1 `bench_alloc_only`
+### 5.1 Throughput (ops/sec)
+
+```
+throughput_ops = round(1,000,000 / mean_us)
+```
+
+- 평균 지연시간의 역수로 초당 처리량 계산
+- **테이블 표시**: `Kops/s` = `throughput_ops / 1000` (천 단위)
+- `mean_us = 0`일 때 `throughput_ops = 0` (mock 백엔드 fast path)
+- **용도**: 힙 간 성능 비교 ("system: 50Kops/s vs reserved: 30Kops/s")
+
+### 5.2 95% 신뢰구간 (Confidence Interval)
+
+```
+ci95_us = ceil(1.96 × stddev / sqrt(n))
+```
+
+- **의미**: 진짜 평균은 95% 확률로 `[avg - ci95, avg + ci95]` 범위 안에 존재
+- **테이블 표시**: `avg±ci95` (예: `12±2`)
+- **z-score 1.96**: 정규분포 95% 양측 임계값
+- **sqrt(n) 효과**: 반복 횟수를 4배로 늘리면 CI가 절반으로 줄어듦
+
+**해석 가이드:**
+
+| CI 상대 크기 | 의미 | 조치 |
+|-------------|------|------|
+| ci95 < avg × 5% | 정밀한 측정 | 그대로 사용 |
+| ci95 = avg × 5~20% | 보통 | `--iterations` 증가 고려 |
+| ci95 > avg × 20% | 부정확 | `--iterations` 증가 필수 또는 외부 간섭 확인 |
+
+### 5.3 테이블 예시
+
+```
+[system]  perf::alloc_only (us)
+     size  min  avg±ci95  tavg  sd  p50  p95   p99  p99.9   max  Kops/s  out
+       4K    5      12±2     8   8    8   25    38     42    42      83    3
+      64K   15     45±5    40  12   40   60    85    110   110      22    2
+       1M   80   250±18   220  45  230  350   480    520   520       4    1
+```
+
+---
+
+## 6. 벤치마크별 상세
+
+### 6.1 `bench_alloc_only`
 
 커널 `DMA_HEAP_IOCTL_ALLOC` 호출의 순수 지연시간.
 
@@ -207,7 +251,7 @@ outlier_count = count(samples WHERE sample IS outlier)
 - **사이즈**: `--sizes` (기본 4K, 64K, 1M)
 - **용도**: 힙 할당자 성능의 기준선
 
-### 5.2 `bench_full_pipeline`
+### 6.2 `bench_full_pipeline`
 
 실제 사용 시나리오: 할당 → 매핑 → 쓰기 → 읽기 → 해제.
 
@@ -215,7 +259,7 @@ outlier_count = count(samples WHERE sample IS outlier)
 - **memwrite**: `write_bytes(ptr, 0xAA, size)` — 전체 버퍼 쓰기
 - **용도**: 캐시 유지보수 비용 포함한 end-to-end 지연
 
-### 5.3 `bench_close`
+### 6.3 `bench_close`
 
 버퍼 해제 경로 지연시간.
 
@@ -223,7 +267,7 @@ outlier_count = count(samples WHERE sample IS outlier)
 - **사전 조건**: 타이밍 전에 alloc 완료
 - **용도**: deferred free pool로의 반환 지연, CMA 반환 비용
 
-### 5.4 `bench_order_boundary`
+### 6.4 `bench_order_boundary`
 
 커널 buddy allocator의 order 경계에서 할당 비용 변화 측정.
 
@@ -231,7 +275,7 @@ outlier_count = count(samples WHERE sample IS outlier)
 - **관찰 포인트**: `49152 (48K)` vs `65536 (64K)` — order 4 경계
 - **용도**: buddy allocator의 order 승격/분할 비용 시각화
 
-### 5.5 `bench_internal_frag`
+### 6.5 `bench_internal_frag`
 
 비정렬 요청 시 내부 단편화 비율.
 
@@ -240,7 +284,7 @@ outlier_count = count(samples WHERE sample IS outlier)
 - **출력**: `frag% = (actual - requested) / requested × 100`
 - **용도**: 힙의 할당 그래뉼래리티(보통 4K) 확인
 
-### 5.6 `bench_pool_warmup`
+### 6.6 `bench_pool_warmup`
 
 cold start vs warm state 할당 비용 비교.
 
@@ -249,7 +293,7 @@ cold start vs warm state 할당 비용 비교.
 - **출력**: `cold_p50, cold_p95, warm_p50, warm_p95`
 - **용도**: 커널 deferred free pool의 효과 정량화
 
-### 5.7 `bench_size_switch`
+### 6.7 `bench_size_switch`
 
 사이즈 전환이 할당 지연에 미치는 영향.
 
@@ -259,7 +303,7 @@ cold start vs warm state 할당 비용 비교.
 
 ---
 
-## 6. JSON 출력 형식
+## 7. JSON 출력 형식
 
 `LatencyStats` 구조체가 그대로 직렬화된다:
 
@@ -276,13 +320,15 @@ cold start vs warm state 할당 비용 비교.
   "p99_9_us": 42,
   "cv_pct": 66.7,
   "trimmed_avg_us": 9,
-  "outlier_count": 3
+  "outlier_count": 3,
+  "throughput_ops": 83333,
+  "ci95_us": 2
 }
 ```
 
 ---
 
-## 7. 정밀도 한계 및 주의사항
+## 8. 정밀도 한계 및 주의사항
 
 | 한계 | 영향 | 완화 방법 |
 |------|------|-----------|
@@ -294,7 +340,7 @@ cold start vs warm state 할당 비용 비교.
 
 ---
 
-## 8. 알고리즘 복잡도
+## 9. 알고리즘 복잡도
 
 | 단계 | 시간 복잡도 | 공간 복잡도 |
 |------|-------------|-------------|

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -381,6 +381,16 @@ cold start vs warm state 할당 비용 비교.
 - **warm**: 100회 alloc/free 사이클 후 100회 측정
 - **출력**: `cold_p50, cold_p95, warm_p50, warm_p95`
 - **용도**: 커널 deferred free pool의 효과 정량화
+- **통계 검정** (`perf::pool_effect`): Welch's t-test + Cohen's d
+  - `t`: t-통계량 (cold - warm). 양수이면 cold가 더 느림
+  - `d`: Cohen's d 효과 크기. `<0.2` negligible, `0.2–0.5` small, `0.5–0.8` medium, `>0.8` large
+  - `sig`: `***` (p<0.001), `**` (p<0.01), `*` (p<0.05), `ns` (not significant)
+  - 정규 근사 사용 (n=100 → df≈198, 정규와 사실상 동일)
+
+```
+[system]  perf::pool_warmup  cold_p50: 45  cold_p95: 80  warm_p50: 12  warm_p95: 25
+[system]  perf::pool_effect  t: 8.32  d: 1.85  sig: ***  effect: large
+```
 
 ### 8.7 `bench_size_switch`
 

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -339,6 +339,26 @@ drift_pct = slope × (n-1) / mean × 100
 - **측정 구간**: alloc → mmap → sync_start(W) → memwrite → sync_end(W) → sync_start(R) → sync_end(R)
 - **memwrite**: `write_bytes(ptr, 0xAA, size)` — 전체 버퍼 쓰기
 - **용도**: 캐시 유지보수 비용 포함한 end-to-end 지연
+- **Stage Breakdown**: 사이즈별로 4개 단계의 개별 지연시간 + 비율 출력
+
+```
+[system]  perf::pipeline_breakdown@64K (us)
+            stage  avg     %
+            alloc   15  30.0
+             mmap    8  16.0
+           sync_w   22  44.0
+           sync_r    5  10.0
+```
+
+| 단계 | 측정 구간 | 포함 연산 |
+|------|-----------|-----------|
+| `alloc` | t0→t1 | `DMA_HEAP_IOCTL_ALLOC` |
+| `mmap` | t1→t2 | `mmap()` syscall |
+| `sync_w` | t2→t3 | `sync_start(W)` + `write_bytes` + `sync_end(W)` |
+| `sync_r` | t3→t4 | `sync_start(R)` + `sync_end(R)` |
+
+- 타이머 오버헤드: `Instant::now()` 5회 × ~20ns = ~100ns/iter (<1% at µs scale)
+- `sync_w`에 `write_bytes`가 포함됨 — 캐시 flush와 메모리 쓰기가 결합된 실제 비용
 
 ### 8.3 `bench_close`
 

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -419,6 +419,19 @@ cold start vs warm state 할당 비용 비교.
 - **3 phase**: 64K×500 → 4K×500 → 64K×500
 - **분석**: 각 phase의 처음 10회 vs 마지막 10회 p50 비교
 - **용도**: 사이즈별 pool이 분리되었는지, 전환 비용이 있는지 확인
+- **Hysteresis** (`perf::hysteresis`): phase 1 vs phase 3 (동일 사이즈) 평균 비교
+  - `ratio = ph3_avg / ph1_avg`. 1.0 = 완전 복귀
+  - `>1.1` degraded, `<0.9` improved, 나머지 recovered
+  - 비가역적 성능 저하가 있는지 (pool fragmentation 등) 감지
+- **Convergence** (`perf::converge_phN`): 사이즈 전환 후 안정화까지 필요한 alloc 수
+  - 10-sample sliding window가 overall mean의 ±5% 이내에 도달하는 최초 지점
+  - 이미 안정적이면 출력 안 함 (no transition cost)
+
+```
+[system]  perf::hysteresis  ph1_avg: 12  ph3_avg: 14  ratio: 1.17  verdict: degraded
+[system]  perf::converge_ph2  after: 35 allocs
+[system]  perf::converge_ph3  after: 22 allocs
+```
 
 ---
 

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -150,6 +150,22 @@ fn percentile_frac(sorted: &[u64], numer: u64, denom: u64) -> u64 {
 
 **제공 백분위수:** p50 (중앙값), p95, p99, p99.9
 
+### 3.6 백분위수 신뢰구간 (Percentile CI)
+
+p99에 대한 95% 비모수 신뢰구간 (binomial order statistics):
+
+```
+rank = ceil(p × n / 100)
+se_rank = sqrt(n × p/100 × (1 - p/100))
+lower = sorted[max(1, floor(rank - 1.96 × se_rank)) - 1]
+upper = sorted[min(n, ceil(rank + 1.96 × se_rank)) - 1]
+```
+
+- **분포 무관** (non-parametric): 정규 분포 가정 불필요
+- **수학적 성질**: `se_rank`는 p=50에서 최대, p=99에서 최소 → 중앙값 CI가 가장 넓음
+- **테이블 표시**: `p99[ci95]` 컬럼 (예: `38[32-45]`)
+- **SLA/SLO 활용**: "p99 ≤ 45µs with 95% confidence"
+
 ---
 
 ## 4. IQR 이상치 탐지 (Outlier Detection)

--- a/src/cmd/aging/mod.rs
+++ b/src/cmd/aging/mod.rs
@@ -438,6 +438,7 @@ impl AgingState {
             outlier_count: 0,
             throughput_ops: if avg > 0 { 1_000_000 / avg } else { 0 },
             ci95_us: 0,
+            mad_us: 0,
         })
     }
 
@@ -1381,6 +1382,7 @@ mod tests {
                 outlier_count: 0,
                 throughput_ops: 20000,
                 ci95_us: 0,
+            mad_us: 0,
             }),
             baseline_avg_us: Some(40),
             final_interval_avg_us: Some(55),
@@ -1575,6 +1577,7 @@ mod tests {
             outlier_count: 0,
             throughput_ops: 20000,
             ci95_us: 0,
+            mad_us: 0,
         };
         let stats2 = LatencyStats {
             count: 20,
@@ -1591,6 +1594,7 @@ mod tests {
             outlier_count: 0,
             throughput_ops: 16667,
             ci95_us: 0,
+            mad_us: 0,
         };
         state.update_cumulative(&stats1);
         state.update_cumulative(&stats2);

--- a/src/cmd/aging/mod.rs
+++ b/src/cmd/aging/mod.rs
@@ -428,9 +428,12 @@ impl AgingState {
             min_us: 0, // not tracked in running stats
             max_us,
             avg_us: avg,
+            stddev_us: 0,     // not tracked in running stats
             p50_us: avg,      // approximation
             p95_us: peak_p99, // approximation
             p99_us: peak_p99,
+            p99_9_us: peak_p99, // approximation
+            cv_pct: 0.0,        // not tracked in running stats
         })
     }
 
@@ -1364,9 +1367,12 @@ mod tests {
                 min_us: 10,
                 max_us: 500,
                 avg_us: 50,
+                stddev_us: 0,
                 p50_us: 45,
                 p95_us: 200,
                 p99_us: 400,
+                p99_9_us: 400,
+                cv_pct: 0.0,
             }),
             baseline_avg_us: Some(40),
             final_interval_avg_us: Some(55),
@@ -1551,18 +1557,24 @@ mod tests {
             min_us: 5,
             max_us: 100,
             avg_us: 50,
+            stddev_us: 0,
             p50_us: 45,
             p95_us: 90,
             p99_us: 95,
+            p99_9_us: 95,
+            cv_pct: 0.0,
         };
         let stats2 = LatencyStats {
             count: 20,
             min_us: 3,
             max_us: 200,
             avg_us: 60,
+            stddev_us: 0,
             p50_us: 55,
             p95_us: 180,
             p99_us: 190,
+            p99_9_us: 190,
+            cv_pct: 0.0,
         };
         state.update_cumulative(&stats1);
         state.update_cumulative(&stats2);

--- a/src/cmd/aging/mod.rs
+++ b/src/cmd/aging/mod.rs
@@ -434,6 +434,8 @@ impl AgingState {
             p99_us: peak_p99,
             p99_9_us: peak_p99, // approximation
             cv_pct: 0.0,        // not tracked in running stats
+            trimmed_avg_us: avg,
+            outlier_count: 0,
         })
     }
 
@@ -1373,6 +1375,8 @@ mod tests {
                 p99_us: 400,
                 p99_9_us: 400,
                 cv_pct: 0.0,
+                trimmed_avg_us: 50,
+                outlier_count: 0,
             }),
             baseline_avg_us: Some(40),
             final_interval_avg_us: Some(55),
@@ -1563,6 +1567,8 @@ mod tests {
             p99_us: 95,
             p99_9_us: 95,
             cv_pct: 0.0,
+            trimmed_avg_us: 50,
+            outlier_count: 0,
         };
         let stats2 = LatencyStats {
             count: 20,
@@ -1575,6 +1581,8 @@ mod tests {
             p99_us: 190,
             p99_9_us: 190,
             cv_pct: 0.0,
+            trimmed_avg_us: 60,
+            outlier_count: 0,
         };
         state.update_cumulative(&stats1);
         state.update_cumulative(&stats2);

--- a/src/cmd/aging/mod.rs
+++ b/src/cmd/aging/mod.rs
@@ -436,6 +436,8 @@ impl AgingState {
             cv_pct: 0.0,        // not tracked in running stats
             trimmed_avg_us: avg,
             outlier_count: 0,
+            throughput_ops: if avg > 0 { 1_000_000 / avg } else { 0 },
+            ci95_us: 0,
         })
     }
 
@@ -1377,6 +1379,8 @@ mod tests {
                 cv_pct: 0.0,
                 trimmed_avg_us: 50,
                 outlier_count: 0,
+                throughput_ops: 20000,
+                ci95_us: 0,
             }),
             baseline_avg_us: Some(40),
             final_interval_avg_us: Some(55),
@@ -1569,6 +1573,8 @@ mod tests {
             cv_pct: 0.0,
             trimmed_avg_us: 50,
             outlier_count: 0,
+            throughput_ops: 20000,
+            ci95_us: 0,
         };
         let stats2 = LatencyStats {
             count: 20,
@@ -1583,6 +1589,8 @@ mod tests {
             cv_pct: 0.0,
             trimmed_avg_us: 60,
             outlier_count: 0,
+            throughput_ops: 16667,
+            ci95_us: 0,
         };
         state.update_cumulative(&stats1);
         state.update_cumulative(&stats2);

--- a/src/cmd/aging/mod.rs
+++ b/src/cmd/aging/mod.rs
@@ -1382,7 +1382,7 @@ mod tests {
                 outlier_count: 0,
                 throughput_ops: 20000,
                 ci95_us: 0,
-            mad_us: 0,
+                mad_us: 0,
             }),
             baseline_avg_us: Some(40),
             final_interval_avg_us: Some(55),

--- a/src/cmd/histogram.rs
+++ b/src/cmd/histogram.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use crate::backend::{DmaBufBackend, HeapBackend};
 use crate::cli::HistMode;
-use crate::cmd::perf::{self, percentile};
+use crate::cmd::perf::{self, percentile, percentile_frac};
 use crate::dmabuf::DmaBuf;
 use crate::fmt;
 use crate::heap::DmaHeap;
@@ -377,14 +377,6 @@ fn build_buckets(sorted: &[u64], min: u64, max: u64, bucket_count: usize) -> Vec
     }
 
     buckets
-}
-
-/// Compute the p-th fractional percentile (e.g., 999/1000 = p99.9).
-fn percentile_frac(sorted: &[u64], numer: u64, denom: u64) -> u64 {
-    let n = sorted.len() as u64;
-    #[allow(clippy::cast_possible_truncation)]
-    let rank = (numer * n).div_ceil(denom) as usize;
-    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
 }
 
 /// Auto-determine bucket count via Sturges' rule: ceil(1 + log2(n)).

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -2055,6 +2055,7 @@ Node 0, zone    Normal
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn format_human_with_heaps_and_memory() {
         let report = InfoReport {
             heaps: vec![HeapEntry {
@@ -2329,7 +2330,7 @@ Node 0, zone    Normal
         assert!(out.contains("CMA migrate type"));
         assert!(out.contains("Normal"));
         // blocks >= order 4 = 2 + 1 + 0 + 0 + 0 + 0 + 0 = 3
-        assert!(out.contains("3"));
+        assert!(out.contains('3'));
     }
 
     #[test]

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -189,6 +189,75 @@ fn format_throughput(ops: u64) -> String {
     }
 }
 
+/// Result of ordinary least-squares linear regression: `y = intercept + slope * x`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LinearFit {
+    /// Fixed base cost (y-intercept), in microseconds.
+    pub intercept_us: f64,
+    /// Marginal cost per byte (slope), in microseconds/byte.
+    pub slope_us_per_byte: f64,
+    /// Coefficient of determination (0.0–1.0). Values near 1.0 indicate
+    /// strong linear relationship between size and latency.
+    pub r_squared: f64,
+}
+
+/// Fit a simple linear model `latency_us = a + b * size_bytes` via OLS.
+///
+/// Requires at least 2 data points. Returns `None` if fewer or if all x values
+/// are identical (zero variance in predictor).
+#[allow(clippy::cast_precision_loss)]
+fn linear_regression(points: &[(u64, u64)]) -> Option<LinearFit> {
+    let n = points.len();
+    if n < 2 {
+        return None;
+    }
+
+    let n_f = n as f64;
+    let sum_x: f64 = points.iter().map(|&(x, _)| x as f64).sum();
+    let sum_y: f64 = points.iter().map(|&(_, y)| y as f64).sum();
+    let mean_x = sum_x / n_f;
+    let mean_y = sum_y / n_f;
+
+    let mut ss_xx = 0.0_f64;
+    let mut ss_cross = 0.0_f64;
+    let mut ss_tot = 0.0_f64;
+    for &(x, y) in points {
+        let dx = x as f64 - mean_x;
+        let dy = y as f64 - mean_y;
+        ss_xx += dx * dx;
+        ss_cross += dx * dy;
+        ss_tot += dy * dy;
+    }
+
+    if ss_xx == 0.0 {
+        return None; // all sizes identical
+    }
+
+    let slope = ss_cross / ss_xx;
+    let intercept = mean_y - slope * mean_x;
+
+    // R² = 1 - SS_res / SS_tot
+    let ss_res: f64 = points
+        .iter()
+        .map(|&(x, y)| {
+            let predicted = intercept + slope * x as f64;
+            let residual = y as f64 - predicted;
+            residual * residual
+        })
+        .sum();
+    let r_squared = if ss_tot > 0.0 {
+        1.0 - ss_res / ss_tot
+    } else {
+        1.0 // all y identical → perfect fit
+    };
+
+    Some(LinearFit {
+        intercept_us: (intercept * 100.0).round() / 100.0,
+        slope_us_per_byte: (slope * 1e9).round() / 1e9, // 9 decimal places
+        r_squared: (r_squared * 1000.0).round() / 1000.0,
+    })
+}
+
 /// Format a byte size as a human-readable string (e.g., 4096 → "4K", 1048576 → "1M").
 ///
 /// Falls back to raw bytes for non-aligned sizes.
@@ -282,6 +351,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
 ) -> nix::Result<()> {
     let heap = DmaHeap::open(backend, heap_name)?;
     let mut rows: Vec<Vec<String>> = Vec::new();
+    let mut regression_points: Vec<(u64, u64)> = Vec::new();
 
     for &size in sizes {
         // Warmup
@@ -303,6 +373,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         }
 
         if let Some(stats) = compute_stats(&samples) {
+            regression_points.push((size, stats.avg_us));
             rows.push(vec![
                 human_size(size),
                 stats.min_us.to_string(),
@@ -341,6 +412,21 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         ],
         &rows,
     );
+
+    // Size-latency regression: latency_us = base + slope * size_bytes
+    if let Some(fit) = linear_regression(&regression_points) {
+        crate::fmt::print_metric(
+            heap_name,
+            heap_w,
+            "perf::alloc_model",
+            &[
+                ("base_us", &format!("{:.1}", fit.intercept_us)),
+                ("us/KB", &format!("{:.3}", fit.slope_us_per_byte * 1024.0)),
+                ("R²", &format!("{:.3}", fit.r_squared)),
+            ],
+        );
+    }
+
     Ok(())
 }
 
@@ -895,6 +981,39 @@ mod tests {
         assert_eq!(format_throughput(100_000), "100");
         assert_eq!(format_throughput(23810), "23");
         assert_eq!(format_throughput(500), "0.5");
+    }
+
+    // ── linear regression tests ──
+
+    #[test]
+    fn regression_too_few_points() {
+        assert!(linear_regression(&[(4096, 10)]).is_none());
+        assert!(linear_regression(&[]).is_none());
+    }
+
+    #[test]
+    fn regression_perfect_linear() {
+        // y = 5 + 0.001 * x → exactly linear
+        let points = vec![(0, 5), (1000, 6), (2000, 7), (3000, 8)];
+        let fit = linear_regression(&points).unwrap();
+        assert!((fit.intercept_us - 5.0).abs() < 0.01);
+        assert!((fit.slope_us_per_byte * 1024.0 - 1.024).abs() < 0.01);
+        assert!((fit.r_squared - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn regression_constant_latency() {
+        // No size dependence: flat latency.
+        let points = vec![(4096, 10), (65536, 10), (1_048_576, 10)];
+        let fit = linear_regression(&points).unwrap();
+        assert!(fit.slope_us_per_byte.abs() < 1e-9);
+        assert!((fit.intercept_us - 10.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn regression_identical_x() {
+        // All same size → undefined slope.
+        assert!(linear_regression(&[(4096, 5), (4096, 10)]).is_none());
     }
 
     // ── bench function tests ──

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -359,6 +359,64 @@ fn iqr_trimmed_mean(sorted: &[u64], raw_mean: f64) -> (u64, usize) {
     (trimmed_avg, n - kept)
 }
 
+/// Compute normalized Shannon entropy of the latency distribution.
+///
+/// Bins samples into a histogram, computes `H = -Σ p_i log2(p_i)`, then
+/// normalizes to `[0, 1]` by dividing by `log2(k)` where k = non-empty bins.
+///
+/// - 0.0 = perfectly deterministic (all identical values)
+/// - 1.0 = maximum unpredictability (uniform across all bins)
+/// - Useful for comparing allocator determinism across heaps/sizes.
+///
+/// Returns `None` if fewer than 4 samples.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn latency_entropy(sorted: &[u64]) -> Option<f64> {
+    let n = sorted.len();
+    if n < 4 {
+        return None;
+    }
+
+    let min_val = sorted[0];
+    let max_val = sorted[n - 1];
+    if min_val == max_val {
+        return Some(0.0); // perfectly deterministic
+    }
+
+    // Sturges' rule for bucket count.
+    let k = ((n as f64).log2().ceil() as usize + 1).max(4);
+    let width = ((max_val - min_val) / k as u64).max(1);
+
+    // Build histogram and compute entropy.
+    let mut counts = vec![0usize; k];
+    for &v in sorted {
+        let idx = ((v - min_val) / width) as usize;
+        counts[idx.min(k - 1)] += 1;
+    }
+
+    let n_f = n as f64;
+    let mut entropy = 0.0_f64;
+    let mut non_empty = 0_usize;
+    for &c in &counts {
+        if c > 0 {
+            let p = c as f64 / n_f;
+            entropy -= p * p.log2();
+            non_empty += 1;
+        }
+    }
+
+    if non_empty <= 1 {
+        return Some(0.0);
+    }
+
+    // Normalize to [0, 1].
+    let max_entropy = (non_empty as f64).log2();
+    Some((entropy / max_entropy * 100.0).round() / 100.0)
+}
+
 /// Compute skewness (3rd moment) and excess kurtosis (4th moment - 3).
 ///
 /// - Skewness > 0: right-tailed (common for latency). Higher = longer tail.
@@ -1069,6 +1127,25 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
                 ("kurtosis", &format!("{kurt:.2}")),
                 ("shape", &tail),
             ],
+        );
+    }
+
+    // Shannon entropy: predictability of latency distribution.
+    if let Some(entropy) = latency_entropy(&{
+        let mut s = last_samples.clone();
+        s.sort_unstable();
+        s
+    }) {
+        let label = match () {
+            () if entropy < 0.3 => "deterministic",
+            () if entropy < 0.7 => "moderate",
+            () => "unpredictable",
+        };
+        crate::fmt::print_metric(
+            heap_name,
+            heap_w,
+            "perf::entropy",
+            &[("H", &format!("{entropy:.2}")), ("predict", &label)],
         );
     }
 
@@ -1970,6 +2047,32 @@ mod tests {
         let (r, ess) = autocorrelation(&samples).unwrap();
         assert!(r > 0.5, "monotonic should have high r: {r}");
         assert!(ess < 50.0, "ESS should be much less than N=100: {ess}");
+    }
+
+    // ── entropy tests ──
+
+    #[test]
+    fn entropy_deterministic() {
+        let sorted = vec![42; 50];
+        assert!((latency_entropy(&sorted).unwrap() - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn entropy_spread() {
+        // Wide uniform distribution: high entropy.
+        let sorted: Vec<u64> = (1..=100).collect();
+        let h = latency_entropy(&sorted).unwrap();
+        assert!(h > 0.8, "uniform should have high entropy: {h}");
+    }
+
+    #[test]
+    fn entropy_concentrated() {
+        // 95 values at 10, 5 at 100: mostly deterministic.
+        let mut sorted = vec![10u64; 95];
+        sorted.extend(vec![100u64; 5]);
+        sorted.sort_unstable();
+        let h = latency_entropy(&sorted).unwrap();
+        assert!(h < 0.5, "concentrated should have low entropy: {h}");
     }
 
     // ── distribution shape tests ──

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -137,6 +137,35 @@ pub(crate) fn percentile_frac(sorted: &[u64], numer: u64, denom: u64) -> u64 {
     sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
 }
 
+/// Compute 95% confidence interval for a percentile using binomial order statistics.
+///
+/// For the p-th percentile (0–100) from n sorted samples, the CI bounds are
+/// order statistics at ranks: `rank ± 1.96 * sqrt(n * p/100 * (1 - p/100))`.
+/// This is distribution-free — no normality assumption required.
+///
+/// Returns `(lower_bound, upper_bound)` from the sorted data.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+pub(crate) fn percentile_ci(sorted: &[u64], p: u32) -> (u64, u64) {
+    let n = sorted.len();
+    if n < 2 {
+        let val = sorted.first().copied().unwrap_or(0);
+        return (val, val);
+    }
+
+    let p_frac = f64::from(p) / 100.0;
+    let rank = (f64::from(p) * n as f64 / 100.0).ceil() as usize;
+    let se_rank = (n as f64 * p_frac * (1.0 - p_frac)).sqrt();
+
+    let lower_rank = (rank as f64 - 1.96 * se_rank).floor().max(1.0) as usize;
+    let upper_rank = (rank as f64 + 1.96 * se_rank).ceil().min(n as f64) as usize;
+
+    (sorted[lower_rank - 1], sorted[upper_rank - 1])
+}
+
 /// Compute trimmed mean by removing IQR outliers from a sorted slice.
 ///
 /// Uses Tukey's fence: outliers are values outside `[Q1 - 1.5*IQR, Q3 + 1.5*IQR]`.
@@ -618,6 +647,11 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         }
 
         if let Some(stats) = compute_stats(&samples) {
+            // Compute p99 CI from sorted samples (non-parametric, binomial order stats).
+            let mut sorted = samples.clone();
+            sorted.sort_unstable();
+            let (p99_lo, p99_hi) = percentile_ci(&sorted, 99);
+
             regression_points.push((size, stats.avg_us));
             last_samples = samples;
             rows.push(vec![
@@ -628,7 +662,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
                 stats.stddev_us.to_string(),
                 stats.p50_us.to_string(),
                 stats.p95_us.to_string(),
-                stats.p99_us.to_string(),
+                format!("{}[{}-{}]", stats.p99_us, p99_lo, p99_hi),
                 stats.p99_9_us.to_string(),
                 stats.max_us.to_string(),
                 format_throughput(stats.throughput_ops),
@@ -650,7 +684,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
             "sd",
             "p50",
             "p95",
-            "p99",
+            "p99[ci95]",
             "p99.9",
             "max",
             "Kops/s",
@@ -1273,6 +1307,50 @@ mod tests {
         let json = serde_json::to_string(&stats).unwrap();
         let deserialized: LatencyStats = serde_json::from_str(&json).unwrap();
         assert_eq!(stats, deserialized);
+    }
+
+    // ── percentile CI tests ──
+
+    #[test]
+    fn percentile_ci_single() {
+        let (lo, hi) = percentile_ci(&[42], 99);
+        assert_eq!(lo, 42);
+        assert_eq!(hi, 42);
+    }
+
+    #[test]
+    fn percentile_ci_100_samples() {
+        let sorted: Vec<u64> = (1..=100).collect();
+        let (lo, hi) = percentile_ci(&sorted, 99);
+        // p99 = 99, CI should bracket it: lower < 99, upper >= 99
+        assert!(lo <= 99, "lower bound {lo} should be ≤ 99");
+        assert!(hi >= 99, "upper bound {hi} should be ≥ 99");
+        // CI width should be small for 100 samples
+        assert!(hi - lo <= 5, "CI too wide: [{lo}, {hi}]");
+    }
+
+    #[test]
+    fn percentile_ci_bounds_within_data() {
+        let sorted: Vec<u64> = (10..=50).collect();
+        let (lo, hi) = percentile_ci(&sorted, 95);
+        assert!(
+            lo >= 10 && hi <= 50,
+            "CI [{lo},{hi}] must be within data range [10,50]"
+        );
+    }
+
+    #[test]
+    fn percentile_ci_median_widest() {
+        // se_rank = sqrt(n*p*(1-p)) is maximized at p=50, so median CI is widest.
+        let sorted: Vec<u64> = (1..=100).collect();
+        let (lo50, hi50) = percentile_ci(&sorted, 50);
+        let (lo99, hi99) = percentile_ci(&sorted, 99);
+        let width50 = hi50 - lo50;
+        let width99 = hi99 - lo99;
+        assert!(
+            width50 >= width99,
+            "p50 CI ({width50}) should be ≥ p99 CI ({width99})"
+        );
     }
 
     // ── percentile edge cases ──

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -259,6 +259,64 @@ struct DriftInfo {
     second_half_avg_us: u64,
 }
 
+/// A detected latency step between two allocation sizes.
+struct OrderStep {
+    size_from: u64,
+    size_to: u64,
+    avg_from: u64,
+    avg_to: u64,
+    /// Buddy allocator order for `size_to`: `ceil(log2(size / PAGE_SIZE))`.
+    order: u32,
+    /// Relative increase: `(avg_to - avg_from) / avg_from * 100`.
+    increase_pct: f64,
+}
+
+/// Detect significant latency steps in order-boundary sweep data.
+///
+/// Scans adjacent `(size, avg_us)` pairs for relative increases > `threshold_pct`.
+/// Returns steps sorted by increase magnitude (largest first).
+#[allow(clippy::cast_precision_loss)]
+fn detect_order_steps(points: &[(u64, u64)], threshold_pct: f64) -> Vec<OrderStep> {
+    const PAGE_SIZE: u64 = 4096;
+
+    let mut steps = Vec::new();
+    for w in points.windows(2) {
+        let (size_from, avg_from) = w[0];
+        let (size_to, avg_to) = w[1];
+
+        if avg_from == 0 {
+            continue;
+        }
+
+        let increase_pct = (avg_to as f64 - avg_from as f64) / avg_from as f64 * 100.0;
+        if increase_pct > threshold_pct {
+            // Buddy order = number of pages needed, expressed as power-of-2 order.
+            let pages = size_to.div_ceil(PAGE_SIZE);
+            let order = if pages <= 1 {
+                0
+            } else {
+                (pages - 1).ilog2() + 1
+            };
+
+            steps.push(OrderStep {
+                size_from,
+                size_to,
+                avg_from,
+                avg_to,
+                order,
+                increase_pct: (increase_pct * 10.0).round() / 10.0,
+            });
+        }
+    }
+
+    steps.sort_by(|a, b| {
+        b.increase_pct
+            .partial_cmp(&a.increase_pct)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    steps
+}
+
 /// Result of ordinary least-squares linear regression: `y = intercept + slope * x`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LinearFit {
@@ -654,6 +712,7 @@ fn bench_order_boundary<B: HeapBackend + DmaBufBackend>(
 ) -> nix::Result<()> {
     let heap = DmaHeap::open(backend, heap_name)?;
     let mut rows: Vec<Vec<String>> = Vec::new();
+    let mut sweep_points: Vec<(u64, u64)> = Vec::new();
 
     for &size in ORDER_BOUNDARY_SIZES {
         // Warmup
@@ -675,6 +734,7 @@ fn bench_order_boundary<B: HeapBackend + DmaBufBackend>(
         }
 
         if let Some(stats) = compute_stats(&samples) {
+            sweep_points.push((size, stats.avg_us));
             rows.push(vec![
                 human_size(size),
                 stats.avg_us.to_string(),
@@ -695,6 +755,23 @@ fn bench_order_boundary<B: HeapBackend + DmaBufBackend>(
         &["size", "avg", "sd", "p50", "p95", "p99", "p99.9"],
         &rows,
     );
+
+    // Detect significant latency steps at order boundaries (>20% increase).
+    let steps = detect_order_steps(&sweep_points, 20.0);
+    for step in &steps {
+        crate::fmt::print_metric(
+            heap_name,
+            heap_w,
+            &format!("perf::order_step (order {})", step.order),
+            &[
+                ("from", &human_size(step.size_from)),
+                ("to", &human_size(step.size_to)),
+                ("avg", &format!("{}→{}us", step.avg_from, step.avg_to)),
+                ("+%", &format!("{:.1}", step.increase_pct)),
+            ],
+        );
+    }
+
     Ok(())
 }
 
@@ -1115,6 +1192,52 @@ mod tests {
             drift.drift_pct
         );
         assert!(drift.first_half_avg_us > drift.second_half_avg_us);
+    }
+
+    // ── order step detection tests ──
+
+    #[test]
+    fn order_steps_empty() {
+        assert!(detect_order_steps(&[], 20.0).is_empty());
+        assert!(detect_order_steps(&[(4096, 10)], 20.0).is_empty());
+    }
+
+    #[test]
+    fn order_steps_no_significant_jump() {
+        // Flat latency across sizes — no steps.
+        let points = vec![(4096, 10), (8192, 11), (16384, 12)];
+        let steps = detect_order_steps(&points, 20.0);
+        assert!(steps.is_empty());
+    }
+
+    #[test]
+    fn order_steps_detects_jump() {
+        // 4K→8K: 10→10 (flat), 8K→64K: 10→20 (100% jump)
+        let points = vec![(4096, 10), (8192, 10), (65536, 20)];
+        let steps = detect_order_steps(&points, 20.0);
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].size_from, 8192);
+        assert_eq!(steps[0].size_to, 65536);
+        assert!((steps[0].increase_pct - 100.0).abs() < 0.1);
+        assert_eq!(steps[0].order, 4); // 65536/4096 = 16 pages = order 4
+    }
+
+    #[test]
+    fn order_steps_sorted_by_magnitude() {
+        let points = vec![(4096, 10), (8192, 15), (65536, 50), (1_048_576, 60)];
+        let steps = detect_order_steps(&points, 20.0);
+        // 8K→64K = +233%, 4K→8K = +50%; 64K→1M = +20% (at threshold)
+        assert!(steps.len() >= 2);
+        assert!(steps[0].increase_pct >= steps[1].increase_pct);
+    }
+
+    #[test]
+    fn order_steps_buddy_order_calc() {
+        // 4096 = 1 page = order 0, 8192 = 2 pages = order 1, etc.
+        let points = vec![(4096, 5), (8192, 20)];
+        let steps = detect_order_steps(&points, 20.0);
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].order, 1); // 8192/4096 = 2 pages → order 1
     }
 
     // ── linear regression tests ──

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -482,6 +482,46 @@ fn detect_order_steps(points: &[(u64, u64)], threshold_pct: f64) -> Vec<OrderSte
     steps
 }
 
+/// A monotonicity inversion: a larger allocation size with lower latency.
+struct Inversion {
+    smaller_size: u64,
+    larger_size: u64,
+    smaller_avg: u64,
+    larger_avg: u64,
+    /// Percentage decrease: `(smaller_avg - larger_avg) / smaller_avg * 100`.
+    decrease_pct: f64,
+}
+
+/// Detect monotonicity inversions in order-boundary sweep data.
+///
+/// Scans adjacent `(size, avg_us)` pairs for cases where a larger size has
+/// *lower* latency — indicating allocator fast-paths or size-class pooling.
+/// Only reports decreases > 10% to filter noise.
+#[allow(clippy::cast_precision_loss)]
+fn detect_inversions(points: &[(u64, u64)]) -> Vec<Inversion> {
+    let mut inversions = Vec::new();
+    for w in points.windows(2) {
+        let (size_s, avg_s) = w[0];
+        let (size_l, avg_l) = w[1];
+
+        if avg_s == 0 || avg_l >= avg_s {
+            continue;
+        }
+
+        let decrease_pct = (avg_s as f64 - avg_l as f64) / avg_s as f64 * 100.0;
+        if decrease_pct > 10.0 {
+            inversions.push(Inversion {
+                smaller_size: size_s,
+                larger_size: size_l,
+                smaller_avg: avg_s,
+                larger_avg: avg_l,
+                decrease_pct: (decrease_pct * 10.0).round() / 10.0,
+            });
+        }
+    }
+    inversions
+}
+
 /// Find the earliest index where a sliding window mean stabilizes within
 /// `tolerance_pct`% of the overall phase mean.
 ///
@@ -1358,6 +1398,21 @@ fn bench_order_boundary<B: HeapBackend + DmaBufBackend>(
         );
     }
 
+    // Monotonicity inversions: larger size with lower latency → fast-path/pool optimization.
+    for inv in detect_inversions(&sweep_points) {
+        crate::fmt::print_metric(
+            heap_name,
+            heap_w,
+            "perf::inversion",
+            &[
+                ("larger", &human_size(inv.larger_size)),
+                ("smaller", &human_size(inv.smaller_size)),
+                ("avg", &format!("{}→{}us", inv.smaller_avg, inv.larger_avg)),
+                ("-%", &format!("{:.1}", inv.decrease_pct)),
+            ],
+        );
+    }
+
     Ok(())
 }
 
@@ -2133,6 +2188,32 @@ mod tests {
         let steps = detect_order_steps(&points, 20.0);
         assert_eq!(steps.len(), 1);
         assert_eq!(steps[0].order, 1); // 8192/4096 = 2 pages → order 1
+    }
+
+    // ── inversion detection tests ──
+
+    #[test]
+    fn inversion_none_for_monotonic() {
+        let points = vec![(4096, 10), (8192, 15), (65536, 30)];
+        assert!(detect_inversions(&points).is_empty());
+    }
+
+    #[test]
+    fn inversion_detects_decrease() {
+        // 64K is faster than 48K — pool optimization.
+        let points = vec![(49152, 20), (65536, 10)];
+        let inv = detect_inversions(&points);
+        assert_eq!(inv.len(), 1);
+        assert_eq!(inv[0].smaller_size, 49152);
+        assert_eq!(inv[0].larger_size, 65536);
+        assert!((inv[0].decrease_pct - 50.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn inversion_ignores_small_decrease() {
+        // 5% decrease — below 10% threshold.
+        let points = vec![(4096, 100), (8192, 95)];
+        assert!(detect_inversions(&points).is_empty());
     }
 
     // ── linear regression tests ──

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -38,6 +38,11 @@ pub struct LatencyStats {
     pub p99_9_us: u64,
     /// Coefficient of variation (stddev / mean * 100). Lower is more stable.
     pub cv_pct: f64,
+    /// Average after removing IQR outliers (1.5 * IQR fence).
+    /// Filters OS scheduler jitter and interrupt noise.
+    pub trimmed_avg_us: u64,
+    /// Number of samples identified as outliers by IQR method.
+    pub outlier_count: usize,
 }
 
 /// Compute latency statistics from a slice of microsecond measurements.
@@ -80,6 +85,9 @@ pub fn compute_stats(samples: &[u64]) -> Option<LatencyStats> {
         0.0
     };
 
+    // IQR outlier detection: fence = [Q1 - 1.5*IQR, Q3 + 1.5*IQR]
+    let (trimmed_avg, outlier_count) = iqr_trimmed_mean(&sorted, mean_f);
+
     Some(LatencyStats {
         count,
         min_us: sorted[0],
@@ -91,6 +99,8 @@ pub fn compute_stats(samples: &[u64]) -> Option<LatencyStats> {
         p99_us: percentile(&sorted, 99),
         p99_9_us: percentile_frac(&sorted, 999, 1000),
         cv_pct: (cv * 10.0).round() / 10.0,
+        trimmed_avg_us: trimmed_avg,
+        outlier_count,
     })
 }
 
@@ -108,6 +118,47 @@ pub(crate) fn percentile_frac(sorted: &[u64], numer: u64, denom: u64) -> u64 {
     #[allow(clippy::cast_possible_truncation)]
     let rank = (numer * n).div_ceil(denom) as usize;
     sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+/// Compute trimmed mean by removing IQR outliers from a sorted slice.
+///
+/// Uses Tukey's fence: outliers are values outside `[Q1 - 1.5*IQR, Q3 + 1.5*IQR]`.
+/// Returns `(trimmed_avg_us, outlier_count)`. Falls back to `raw_mean` if all
+/// samples are outliers (degenerate case).
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation
+)]
+fn iqr_trimmed_mean(sorted: &[u64], raw_mean: f64) -> (u64, usize) {
+    let n = sorted.len();
+    if n < 4 {
+        // Too few samples for meaningful IQR; return raw mean.
+        return (raw_mean.round() as u64, 0);
+    }
+
+    let q1 = percentile(sorted, 25) as f64;
+    let q3 = percentile(sorted, 75) as f64;
+    let iqr = q3 - q1;
+    let lower = q1 - 1.5 * iqr;
+    let upper = q3 + 1.5 * iqr;
+
+    let mut sum = 0.0_f64;
+    let mut kept = 0_usize;
+    for &v in sorted {
+        let vf = v as f64;
+        if vf >= lower && vf <= upper {
+            sum += vf;
+            kept += 1;
+        }
+    }
+
+    if kept == 0 {
+        return (raw_mean.round() as u64, n);
+    }
+
+    let trimmed_avg = (sum / kept as f64).round() as u64;
+    (trimmed_avg, n - kept)
 }
 
 use crate::probe::align_to;
@@ -230,12 +281,14 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
                 human_size(size),
                 stats.min_us.to_string(),
                 stats.avg_us.to_string(),
+                stats.trimmed_avg_us.to_string(),
                 stats.stddev_us.to_string(),
                 stats.p50_us.to_string(),
                 stats.p95_us.to_string(),
                 stats.p99_us.to_string(),
                 stats.p99_9_us.to_string(),
                 stats.max_us.to_string(),
+                stats.outlier_count.to_string(),
             ]);
         }
     }
@@ -246,7 +299,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         "perf::alloc_only",
         Some("(us)"),
         &[
-            "size", "min", "avg", "sd", "p50", "p95", "p99", "p99.9", "max",
+            "size", "min", "avg", "tavg", "sd", "p50", "p95", "p99", "p99.9", "max", "out",
         ],
         &rows,
     );
@@ -720,6 +773,50 @@ mod tests {
         assert_eq!(human_size(4095), "4095");
         assert_eq!(human_size(49152), "48K");
         assert_eq!(human_size(1), "1");
+    }
+
+    // ── IQR outlier tests ──
+
+    #[test]
+    fn iqr_no_outliers_uniform() {
+        // Uniform data: no outliers expected.
+        let samples = vec![100; 20];
+        let stats = compute_stats(&samples).unwrap();
+        assert_eq!(stats.outlier_count, 0);
+        assert_eq!(stats.trimmed_avg_us, 100);
+    }
+
+    #[test]
+    fn iqr_detects_outlier() {
+        // 19 values of 10, one extreme outlier at 1000.
+        let mut samples = vec![10u64; 19];
+        samples.push(1000);
+        let stats = compute_stats(&samples).unwrap();
+        assert!(stats.outlier_count >= 1);
+        // Trimmed avg should be close to 10 (the non-outlier value).
+        assert!(stats.trimmed_avg_us <= 10);
+        // Raw avg is pulled up by the outlier.
+        assert!(stats.avg_us > stats.trimmed_avg_us);
+    }
+
+    #[test]
+    fn iqr_small_sample_no_filter() {
+        // < 4 samples: IQR not applied.
+        let stats = compute_stats(&[5, 10, 1000]).unwrap();
+        assert_eq!(stats.outlier_count, 0);
+        // trimmed_avg equals raw avg for small samples.
+        assert_eq!(stats.trimmed_avg_us, stats.avg_us);
+    }
+
+    #[test]
+    fn iqr_preserves_json_roundtrip() {
+        let mut samples = vec![50u64; 30];
+        samples.push(500); // outlier
+        let stats = compute_stats(&samples).unwrap();
+        let json = serde_json::to_string(&stats).unwrap();
+        let back: LatencyStats = serde_json::from_str(&json).unwrap();
+        assert_eq!(stats, back);
+        assert!(back.outlier_count > 0);
     }
 
     // ── bench function tests ──

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -655,7 +655,14 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
     Ok(())
 }
 
-/// Benchmark full pipeline: alloc + mmap + sync(write) + write + sync(read) + unmap.
+/// Pipeline stage names for breakdown analysis.
+const STAGE_NAMES: &[&str] = &["alloc", "mmap", "sync_w", "write", "sync_r"];
+
+/// Benchmark full pipeline with per-stage breakdown.
+///
+/// Times each stage individually: alloc, mmap, `sync_start`(W)+`sync_end`(W),
+/// `write_bytes`, `sync_start`(R)+`sync_end`(R). Reports both total and
+/// per-stage average with percentage of total.
 #[allow(clippy::cast_possible_truncation)]
 fn bench_full_pipeline<B: HeapBackend + DmaBufBackend>(
     backend: &B,
@@ -666,7 +673,7 @@ fn bench_full_pipeline<B: HeapBackend + DmaBufBackend>(
     heap_w: usize,
 ) -> nix::Result<()> {
     let heap = DmaHeap::open(backend, heap_name)?;
-    let mut rows: Vec<Vec<String>> = Vec::new();
+    let mut total_rows: Vec<Vec<String>> = Vec::new();
 
     for &size in sizes {
         // Warmup
@@ -680,33 +687,78 @@ fn bench_full_pipeline<B: HeapBackend + DmaBufBackend>(
             drop(buf);
         }
 
-        // Measure
-        let mut samples = Vec::with_capacity(iterations as usize);
+        // Per-stage sample collectors (5 stages).
+        let stage_count = STAGE_NAMES.len();
+        let mut stage_samples: Vec<Vec<u64>> = (0..stage_count)
+            .map(|_| Vec::with_capacity(iterations as usize))
+            .collect();
+        let mut total_samples = Vec::with_capacity(iterations as usize);
+
         for _ in 0..iterations {
-            let start = Instant::now();
+            let t0 = Instant::now();
             let fd = heap.alloc(size, DMA_HEAP_ALLOC_FD_FLAGS, DMA_HEAP_VALID_HEAP_FLAGS)?;
+            let t1 = Instant::now();
             let mut buf = DmaBuf::new(backend, fd, size as usize);
             let ptr = buf.mmap()?;
+            let t2 = Instant::now();
             buf.sync_start(DMA_BUF_SYNC_WRITE)?;
             unsafe { std::ptr::write_bytes(ptr, 0xAA, size as usize) };
             buf.sync_end(DMA_BUF_SYNC_WRITE)?;
+            let t3 = Instant::now();
+            // Separate write from sync for attribution — already included in sync_w above,
+            // but we track the read-sync pair independently.
             buf.sync_start(DMA_BUF_SYNC_READ)?;
             buf.sync_end(DMA_BUF_SYNC_READ)?;
-            let elapsed = start.elapsed().as_micros() as u64;
-            samples.push(elapsed);
+            let t4 = Instant::now();
+
+            stage_samples[0].push(t1.duration_since(t0).as_micros() as u64); // alloc
+            stage_samples[1].push(t2.duration_since(t1).as_micros() as u64); // mmap
+            stage_samples[2].push(t3.duration_since(t2).as_micros() as u64); // sync_w + write
+            // write is embedded in sync_w measurement — report combined
+            stage_samples[3].push(0); // placeholder: write cost embedded in sync_w
+            stage_samples[4].push(t4.duration_since(t3).as_micros() as u64); // sync_r
+            total_samples.push(t4.duration_since(t0).as_micros() as u64);
+
             drop(buf);
         }
 
-        if let Some(stats) = compute_stats(&samples) {
-            rows.push(vec![
+        if let Some(total_stats) = compute_stats(&total_samples) {
+            total_rows.push(vec![
                 human_size(size),
-                stats.avg_us.to_string(),
-                stats.stddev_us.to_string(),
-                stats.p50_us.to_string(),
-                stats.p95_us.to_string(),
-                stats.p99_us.to_string(),
-                stats.p99_9_us.to_string(),
+                total_stats.avg_us.to_string(),
+                total_stats.stddev_us.to_string(),
+                total_stats.p50_us.to_string(),
+                total_stats.p95_us.to_string(),
+                total_stats.p99_us.to_string(),
+                total_stats.p99_9_us.to_string(),
             ]);
+
+            // Per-stage breakdown (skip placeholder stage 3 "write").
+            #[allow(clippy::cast_precision_loss)]
+            let total_avg_f = total_stats.avg_us.max(1) as f64;
+            let mut breakdown_rows: Vec<Vec<String>> = Vec::new();
+            for (i, name) in STAGE_NAMES.iter().enumerate() {
+                if i == 3 {
+                    continue; // write embedded in sync_w
+                }
+                if let Some(st) = compute_stats(&stage_samples[i]) {
+                    #[allow(clippy::cast_precision_loss)]
+                    let pct = st.avg_us as f64 / total_avg_f * 100.0;
+                    breakdown_rows.push(vec![
+                        (*name).to_string(),
+                        st.avg_us.to_string(),
+                        format!("{pct:.1}"),
+                    ]);
+                }
+            }
+            crate::fmt::print_table(
+                heap_name,
+                heap_w,
+                &format!("perf::pipeline_breakdown@{}", human_size(size)),
+                Some("(us)"),
+                &["stage", "avg", "%"],
+                &breakdown_rows,
+            );
         }
     }
 
@@ -716,7 +768,7 @@ fn bench_full_pipeline<B: HeapBackend + DmaBufBackend>(
         "perf::full_pipeline",
         Some("(us)"),
         &["size", "avg", "sd", "p50", "p95", "p99", "p99.9"],
-        &rows,
+        &total_rows,
     );
     Ok(())
 }

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -31,14 +31,27 @@ pub struct LatencyStats {
     pub min_us: u64,
     pub max_us: u64,
     pub avg_us: u64,
+    pub stddev_us: u64,
     pub p50_us: u64,
     pub p95_us: u64,
     pub p99_us: u64,
+    pub p99_9_us: u64,
+    /// Coefficient of variation (stddev / mean * 100). Lower is more stable.
+    pub cv_pct: f64,
 }
 
 /// Compute latency statistics from a slice of microsecond measurements.
 ///
+/// Uses exact floating-point mean for variance calculation, then rounds for
+/// integer fields. Population stddev (divide by N) is used since benchmark
+/// iterations represent the full measurement, not a sample from a larger population.
+///
 /// Returns `None` if the slice is empty.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation
+)]
 pub fn compute_stats(samples: &[u64]) -> Option<LatencyStats> {
     if samples.is_empty() {
         return None;
@@ -49,15 +62,35 @@ pub fn compute_stats(samples: &[u64]) -> Option<LatencyStats> {
 
     let count = sorted.len();
     let sum: u64 = sorted.iter().sum();
+    let mean_f = sum as f64 / count as f64;
+
+    // Population variance via two-pass algorithm (numerically stable for integer data).
+    let variance = sorted
+        .iter()
+        .map(|&x| {
+            let diff = x as f64 - mean_f;
+            diff * diff
+        })
+        .sum::<f64>()
+        / count as f64;
+    let stddev = variance.sqrt();
+    let cv = if mean_f > 0.0 {
+        stddev / mean_f * 100.0
+    } else {
+        0.0
+    };
 
     Some(LatencyStats {
         count,
         min_us: sorted[0],
         max_us: sorted[count - 1],
-        avg_us: sum / count as u64,
+        avg_us: mean_f.round() as u64,
+        stddev_us: stddev.round() as u64,
         p50_us: percentile(&sorted, 50),
         p95_us: percentile(&sorted, 95),
         p99_us: percentile(&sorted, 99),
+        p99_9_us: percentile_frac(&sorted, 999, 1000),
+        cv_pct: (cv * 10.0).round() / 10.0,
     })
 }
 
@@ -69,7 +102,28 @@ pub(crate) fn percentile(sorted: &[u64], p: u32) -> u64 {
     sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
 }
 
+/// Compute the fractional percentile (e.g., 999/1000 = p99.9) from a sorted slice.
+pub(crate) fn percentile_frac(sorted: &[u64], numer: u64, denom: u64) -> u64 {
+    let n = sorted.len() as u64;
+    #[allow(clippy::cast_possible_truncation)]
+    let rank = (numer * n).div_ceil(denom) as usize;
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
 use crate::probe::align_to;
+
+/// Format a byte size as a human-readable string (e.g., 4096 → "4K", 1048576 → "1M").
+///
+/// Falls back to raw bytes for non-aligned sizes.
+fn human_size(bytes: u64) -> String {
+    if bytes >= 1_048_576 && bytes.is_multiple_of(1_048_576) {
+        format!("{}M", bytes / 1_048_576)
+    } else if bytes >= 1024 && bytes.is_multiple_of(1024) {
+        format!("{}K", bytes / 1024)
+    } else {
+        bytes.to_string()
+    }
+}
 
 /// Run all stage 3 performance tests.
 /// Returns sub-test results (and the first error, if any).
@@ -173,12 +227,14 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
 
         if let Some(stats) = compute_stats(&samples) {
             rows.push(vec![
-                size.to_string(),
+                human_size(size),
                 stats.min_us.to_string(),
                 stats.avg_us.to_string(),
+                stats.stddev_us.to_string(),
                 stats.p50_us.to_string(),
                 stats.p95_us.to_string(),
                 stats.p99_us.to_string(),
+                stats.p99_9_us.to_string(),
                 stats.max_us.to_string(),
             ]);
         }
@@ -189,7 +245,9 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         heap_w,
         "perf::alloc_only",
         Some("(us)"),
-        &["size", "min", "avg", "p50", "p95", "p99", "max"],
+        &[
+            "size", "min", "avg", "sd", "p50", "p95", "p99", "p99.9", "max",
+        ],
         &rows,
     );
     Ok(())
@@ -239,11 +297,13 @@ fn bench_full_pipeline<B: HeapBackend + DmaBufBackend>(
 
         if let Some(stats) = compute_stats(&samples) {
             rows.push(vec![
-                size.to_string(),
+                human_size(size),
                 stats.avg_us.to_string(),
+                stats.stddev_us.to_string(),
                 stats.p50_us.to_string(),
                 stats.p95_us.to_string(),
                 stats.p99_us.to_string(),
+                stats.p99_9_us.to_string(),
             ]);
         }
     }
@@ -253,7 +313,7 @@ fn bench_full_pipeline<B: HeapBackend + DmaBufBackend>(
         heap_w,
         "perf::full_pipeline",
         Some("(us)"),
-        &["size", "avg", "p50", "p95", "p99"],
+        &["size", "avg", "sd", "p50", "p95", "p99", "p99.9"],
         &rows,
     );
     Ok(())
@@ -293,11 +353,13 @@ fn bench_close<B: HeapBackend + DmaBufBackend>(
 
         if let Some(stats) = compute_stats(&samples) {
             rows.push(vec![
-                size.to_string(),
+                human_size(size),
                 stats.avg_us.to_string(),
+                stats.stddev_us.to_string(),
                 stats.p50_us.to_string(),
                 stats.p95_us.to_string(),
                 stats.p99_us.to_string(),
+                stats.p99_9_us.to_string(),
             ]);
         }
     }
@@ -307,7 +369,7 @@ fn bench_close<B: HeapBackend + DmaBufBackend>(
         heap_w,
         "perf::close",
         Some("(us)"),
-        &["size", "avg", "p50", "p95", "p99"],
+        &["size", "avg", "sd", "p50", "p95", "p99", "p99.9"],
         &rows,
     );
     Ok(())
@@ -346,11 +408,13 @@ fn bench_order_boundary<B: HeapBackend + DmaBufBackend>(
 
         if let Some(stats) = compute_stats(&samples) {
             rows.push(vec![
-                size.to_string(),
+                human_size(size),
                 stats.avg_us.to_string(),
+                stats.stddev_us.to_string(),
                 stats.p50_us.to_string(),
                 stats.p95_us.to_string(),
                 stats.p99_us.to_string(),
+                stats.p99_9_us.to_string(),
             ]);
         }
     }
@@ -360,7 +424,7 @@ fn bench_order_boundary<B: HeapBackend + DmaBufBackend>(
         heap_w,
         "perf::order_boundary",
         Some("(us)"),
-        &["size", "avg", "p50", "p95", "p99"],
+        &["size", "avg", "sd", "p50", "p95", "p99", "p99.9"],
         &rows,
     );
     Ok(())
@@ -475,7 +539,7 @@ fn bench_size_switch<B: HeapBackend + DmaBufBackend>(
         if let (Some(first), Some(last)) = (first_10(samples), last_10(samples)) {
             rows.push(vec![
                 ph.to_string(),
-                size.to_string(),
+                human_size(*size),
                 first.p50_us.to_string(),
                 last.p50_us.to_string(),
             ]);
@@ -551,9 +615,12 @@ mod tests {
         assert_eq!(stats.min_us, 42);
         assert_eq!(stats.max_us, 42);
         assert_eq!(stats.avg_us, 42);
+        assert_eq!(stats.stddev_us, 0);
         assert_eq!(stats.p50_us, 42);
         assert_eq!(stats.p95_us, 42);
         assert_eq!(stats.p99_us, 42);
+        assert_eq!(stats.p99_9_us, 42);
+        assert!((stats.cv_pct - 0.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -563,10 +630,15 @@ mod tests {
         assert_eq!(stats.count, 100);
         assert_eq!(stats.min_us, 1);
         assert_eq!(stats.max_us, 100);
-        assert_eq!(stats.avg_us, 50); // (1+100)*100/2/100 = 50.5 → 50
+        assert_eq!(stats.avg_us, 51); // (1+100)*100/2/100 = 50.5 → rounds to 51
         assert_eq!(stats.p50_us, 50);
         assert_eq!(stats.p95_us, 95);
         assert_eq!(stats.p99_us, 99);
+        assert_eq!(stats.p99_9_us, 100);
+        // stddev of 1..=100: sqrt((100^2-1)/12) ≈ 28.87 → rounds to 29
+        assert_eq!(stats.stddev_us, 29);
+        // cv = 28.87/50.5*100 ≈ 57.2
+        assert!((stats.cv_pct - 57.2).abs() < 0.1);
     }
 
     #[test]
@@ -593,6 +665,61 @@ mod tests {
         let sorted = vec![10, 20];
         assert_eq!(percentile(&sorted, 50), 10);
         assert_eq!(percentile(&sorted, 99), 20);
+    }
+
+    #[test]
+    fn percentile_frac_p999() {
+        let sorted: Vec<u64> = (1..=1000).collect();
+        assert_eq!(percentile_frac(&sorted, 999, 1000), 999);
+    }
+
+    #[test]
+    fn percentile_frac_small_sample() {
+        let sorted = vec![5, 10, 15];
+        // 999/1000 of 3 elements → rank = ceil(2997/1000) = 3 → index 2
+        assert_eq!(percentile_frac(&sorted, 999, 1000), 15);
+    }
+
+    // ── stddev / cv tests ──
+
+    #[test]
+    fn stats_uniform_zero_stddev() {
+        let samples = vec![100; 50];
+        let stats = compute_stats(&samples).unwrap();
+        assert_eq!(stats.avg_us, 100);
+        assert_eq!(stats.stddev_us, 0);
+        assert!((stats.cv_pct - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn stats_two_values_stddev() {
+        // [10, 20]: mean=15, variance=(25+25)/2=25, stddev=5
+        let stats = compute_stats(&[10, 20]).unwrap();
+        assert_eq!(stats.avg_us, 15);
+        assert_eq!(stats.stddev_us, 5);
+        // cv = 5/15*100 = 33.3
+        assert!((stats.cv_pct - 33.3).abs() < 0.1);
+    }
+
+    // ── human_size tests ──
+
+    #[test]
+    fn human_size_kilobytes() {
+        assert_eq!(human_size(4096), "4K");
+        assert_eq!(human_size(65536), "64K");
+    }
+
+    #[test]
+    fn human_size_megabytes() {
+        assert_eq!(human_size(1_048_576), "1M");
+        assert_eq!(human_size(8_388_608), "8M");
+    }
+
+    #[test]
+    fn human_size_unaligned() {
+        assert_eq!(human_size(4095), "4095");
+        assert_eq!(human_size(49152), "48K");
+        assert_eq!(human_size(1), "1");
     }
 
     // ── bench function tests ──

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -1052,6 +1052,33 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         );
     }
 
+    // CI convergence: how fast does CI shrink with more samples?
+    // Computes CI at 25%, 50%, 75%, 100% of samples to show convergence rate.
+    if last_samples.len() >= 20 {
+        let n = last_samples.len();
+        let quarters = [n / 4, n / 2, n * 3 / 4, n];
+        let mut ci_rows: Vec<Vec<String>> = Vec::new();
+        for &q in &quarters {
+            if let Some(st) = compute_stats(&last_samples[..q]) {
+                ci_rows.push(vec![
+                    q.to_string(),
+                    st.avg_us.to_string(),
+                    format!("±{}", st.ci95_us),
+                ]);
+            }
+        }
+        if ci_rows.len() == 4 {
+            crate::fmt::print_table(
+                heap_name,
+                heap_w,
+                "perf::ci_convergence",
+                Some("(us)"),
+                &["N", "avg", "ci95"],
+                &ci_rows,
+            );
+        }
+    }
+
     // Quality scorecard: aggregate all diagnostic signals.
     let drift_pct = detect_drift(&last_samples).map_or(0.0, |d| d.drift_pct);
     let stat_refs: Vec<&LatencyStats> = all_stats.iter().collect();

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -317,6 +317,46 @@ fn detect_order_steps(points: &[(u64, u64)], threshold_pct: f64) -> Vec<OrderSte
     steps
 }
 
+/// Find the earliest index where a sliding window mean stabilizes within
+/// `tolerance_pct`% of the overall phase mean.
+///
+/// Returns the number of samples needed to converge, or `None` if the phase
+/// is stable from the start (window 0 already within tolerance).
+#[allow(clippy::cast_precision_loss)]
+fn convergence_index(samples: &[u64], window: usize, tolerance_pct: f64) -> Option<usize> {
+    if samples.len() < window {
+        return None;
+    }
+
+    let overall_mean: f64 = samples.iter().map(|&v| v as f64).sum::<f64>() / samples.len() as f64;
+    if overall_mean == 0.0 {
+        return None;
+    }
+
+    let threshold = overall_mean * tolerance_pct / 100.0;
+
+    // Check if first window is already converged — no transition cost.
+    let first_win_mean: f64 =
+        samples[..window].iter().map(|&v| v as f64).sum::<f64>() / window as f64;
+    if (first_win_mean - overall_mean).abs() <= threshold {
+        return None; // stable from the start
+    }
+
+    // Scan forward to find convergence point.
+    for start in 1..=samples.len().saturating_sub(window) {
+        let win_mean: f64 = samples[start..start + window]
+            .iter()
+            .map(|&v| v as f64)
+            .sum::<f64>()
+            / window as f64;
+        if (win_mean - overall_mean).abs() <= threshold {
+            return Some(start + window);
+        }
+    }
+
+    None // never converged
+}
+
 /// Result of Welch's t-test comparing two independent sample groups.
 struct WelchResult {
     /// Welch's t-statistic.
@@ -1035,6 +1075,44 @@ fn bench_size_switch<B: HeapBackend + DmaBufBackend>(
     }
     crate::fmt::print_table(heap_name, heap_w, "perf::size_switch", None, headers, &rows);
 
+    // Hysteresis: does phase 3 (back to size_a) recover to phase 1 level?
+    if let (Some(p1), Some(p3)) = (compute_stats(&phase1), compute_stats(&phase3)) {
+        #[allow(clippy::cast_precision_loss)]
+        if let Some(ratio) = (p1.avg_us > 0).then(|| p3.avg_us as f64 / p1.avg_us as f64) {
+            let ratio_str = format!("{ratio:.2}");
+            let verdict = if ratio > 1.1 {
+                "degraded"
+            } else if ratio < 0.9 {
+                "improved"
+            } else {
+                "recovered"
+            };
+            crate::fmt::print_metric(
+                heap_name,
+                heap_w,
+                "perf::hysteresis",
+                &[
+                    ("ph1_avg", &p1.avg_us),
+                    ("ph3_avg", &p3.avg_us),
+                    ("ratio", &ratio_str),
+                    ("verdict", &verdict),
+                ],
+            );
+        }
+    }
+
+    // Convergence: how many allocs until each phase stabilizes?
+    for (ph, samples) in [(2, &phase2), (3, &phase3)] {
+        if let Some(n) = convergence_index(samples, 10, 5.0) {
+            crate::fmt::print_metric(
+                heap_name,
+                heap_w,
+                &format!("perf::converge_ph{ph}"),
+                &[("after", &format!("{n} allocs"))],
+            );
+        }
+    }
+
     Ok(())
 }
 
@@ -1216,6 +1294,37 @@ mod tests {
         assert_eq!(human_size(4095), "4095");
         assert_eq!(human_size(49152), "48K");
         assert_eq!(human_size(1), "1");
+    }
+
+    // ── convergence tests ──
+
+    #[test]
+    fn convergence_too_short() {
+        assert!(convergence_index(&[1, 2, 3], 10, 5.0).is_none());
+    }
+
+    #[test]
+    fn convergence_already_stable() {
+        // Uniform data: first window already at overall mean.
+        let samples = vec![100; 50];
+        assert!(convergence_index(&samples, 10, 5.0).is_none());
+    }
+
+    #[test]
+    fn convergence_after_spike() {
+        // First 10 values high (200), rest normal (100). Should converge around index 20.
+        let mut samples = vec![200u64; 10];
+        samples.extend(vec![100u64; 90]);
+        let idx = convergence_index(&samples, 10, 5.0);
+        assert!(idx.is_some());
+        let n = idx.unwrap();
+        assert!(n > 10 && n <= 30, "should converge between 10-30, got {n}");
+    }
+
+    #[test]
+    fn convergence_zero_mean() {
+        let samples = vec![0u64; 50];
+        assert!(convergence_index(&samples, 10, 5.0).is_none());
     }
 
     // ── IQR outlier tests ──

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -189,6 +189,76 @@ fn format_throughput(ops: u64) -> String {
     }
 }
 
+/// Detect monotonic drift in measurement samples over time.
+///
+/// Fits a linear regression of `(sample_index, latency)` and reports the total
+/// drift as a percentage of the mean. Positive drift = degradation over time
+/// (thermal throttling, memory pressure), negative = warmup still settling.
+///
+/// Returns `None` if fewer than 10 samples (insufficient for meaningful trend).
+#[allow(clippy::cast_precision_loss)]
+fn detect_drift(samples: &[u64]) -> Option<DriftInfo> {
+    let n = samples.len();
+    if n < 10 {
+        return None;
+    }
+
+    let n_f = n as f64;
+    // x values are 0..n-1 (sample indices).
+    // mean_x = (n-1)/2, sum_x = n*(n-1)/2
+    let mean_x = (n_f - 1.0) / 2.0;
+    let mean_y: f64 = samples.iter().map(|&v| v as f64).sum::<f64>() / n_f;
+
+    if mean_y == 0.0 {
+        return Some(DriftInfo {
+            drift_pct: 0.0,
+            first_half_avg_us: 0,
+            second_half_avg_us: 0,
+        });
+    }
+
+    // SS_xx for indices 0..n-1: n*(n-1)*(2n-1)/6 - n*(n-1)^2/4
+    // Simplified: n*(n^2-1)/12
+    let ss_xx = n_f * (n_f * n_f - 1.0) / 12.0;
+
+    let ss_cross: f64 = samples
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| (i as f64 - mean_x) * (v as f64 - mean_y))
+        .sum();
+
+    let slope = ss_cross / ss_xx;
+
+    // Total drift as percentage of mean: slope * (n-1) / mean * 100
+    let total_drift = slope * (n_f - 1.0);
+    let drift_pct = (total_drift / mean_y * 100.0 * 10.0).round() / 10.0;
+
+    // Half-split averages for intuitive comparison.
+    let mid = n / 2;
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let first_half_avg =
+        (samples[..mid].iter().map(|&v| v as f64).sum::<f64>() / mid as f64).round() as u64;
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let second_half_avg =
+        (samples[mid..].iter().map(|&v| v as f64).sum::<f64>() / (n - mid) as f64).round() as u64;
+
+    Some(DriftInfo {
+        drift_pct,
+        first_half_avg_us: first_half_avg,
+        second_half_avg_us: second_half_avg,
+    })
+}
+
+/// Measurement drift diagnostic info.
+struct DriftInfo {
+    /// Total drift as percentage of mean. Positive = degradation, negative = warmup settling.
+    drift_pct: f64,
+    /// Average latency of first half of samples.
+    first_half_avg_us: u64,
+    /// Average latency of second half of samples.
+    second_half_avg_us: u64,
+}
+
 /// Result of ordinary least-squares linear regression: `y = intercept + slope * x`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LinearFit {
@@ -352,6 +422,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
     let heap = DmaHeap::open(backend, heap_name)?;
     let mut rows: Vec<Vec<String>> = Vec::new();
     let mut regression_points: Vec<(u64, u64)> = Vec::new();
+    let mut last_samples: Vec<u64> = Vec::new();
 
     for &size in sizes {
         // Warmup
@@ -374,6 +445,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
 
         if let Some(stats) = compute_stats(&samples) {
             regression_points.push((size, stats.avg_us));
+            last_samples = samples;
             rows.push(vec![
                 human_size(size),
                 stats.min_us.to_string(),
@@ -422,7 +494,26 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
             &[
                 ("base_us", &format!("{:.1}", fit.intercept_us)),
                 ("us/KB", &format!("{:.3}", fit.slope_us_per_byte * 1024.0)),
-                ("R²", &format!("{:.3}", fit.r_squared)),
+                ("R\u{b2}", &format!("{:.3}", fit.r_squared)),
+            ],
+        );
+    }
+
+    // Drift detection on the last (largest) size — most sensitive to thermal/pressure effects.
+    if let Some(drift) = detect_drift(&last_samples).filter(|d| d.drift_pct.abs() > 10.0) {
+        let direction = if drift.drift_pct > 0.0 {
+            "degrading"
+        } else {
+            "improving"
+        };
+        crate::fmt::print_metric(
+            heap_name,
+            heap_w,
+            &format!("perf::drift_warn ({direction})"),
+            &[
+                ("drift", &format!("{:+.1}%", drift.drift_pct)),
+                ("1st_half", &drift.first_half_avg_us),
+                ("2nd_half", &drift.second_half_avg_us),
             ],
         );
     }
@@ -981,6 +1072,49 @@ mod tests {
         assert_eq!(format_throughput(100_000), "100");
         assert_eq!(format_throughput(23810), "23");
         assert_eq!(format_throughput(500), "0.5");
+    }
+
+    // ── drift detection tests ──
+
+    #[test]
+    fn drift_too_few_samples() {
+        assert!(detect_drift(&[1, 2, 3]).is_none());
+    }
+
+    #[test]
+    fn drift_stable_samples() {
+        let samples = vec![100; 20];
+        let drift = detect_drift(&samples).unwrap();
+        assert!((drift.drift_pct - 0.0).abs() < f64::EPSILON);
+        assert_eq!(drift.first_half_avg_us, 100);
+        assert_eq!(drift.second_half_avg_us, 100);
+    }
+
+    #[test]
+    fn drift_increasing_trend() {
+        // Linearly increasing: 10, 20, 30, ..., 200
+        let samples: Vec<u64> = (1..=20).map(|i| i * 10).collect();
+        let drift = detect_drift(&samples).unwrap();
+        // Strong positive drift expected.
+        assert!(
+            drift.drift_pct > 50.0,
+            "drift should be large positive: {}",
+            drift.drift_pct
+        );
+        assert!(drift.second_half_avg_us > drift.first_half_avg_us);
+    }
+
+    #[test]
+    fn drift_decreasing_trend() {
+        // Linearly decreasing: 200, 190, ..., 10
+        let samples: Vec<u64> = (1..=20).rev().map(|i| i * 10).collect();
+        let drift = detect_drift(&samples).unwrap();
+        assert!(
+            drift.drift_pct < -50.0,
+            "drift should be large negative: {}",
+            drift.drift_pct
+        );
+        assert!(drift.first_half_avg_us > drift.second_half_avg_us);
     }
 
     // ── linear regression tests ──

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -654,6 +654,38 @@ fn welch_test(a: &[u64], b: &[u64]) -> Option<WelchResult> {
     })
 }
 
+/// Aggregated analysis results for JSON output.
+///
+/// Captures all advanced diagnostics so they can be serialized alongside
+/// basic `LatencyStats` in the JSON output for programmatic consumption.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerfAnalysis {
+    /// Per-size latency statistics.
+    pub stats: Vec<SizeStats>,
+    /// Size-latency linear regression model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub regression: Option<LinearFit>,
+    /// Quality scorecard (0-100).
+    pub quality_score: u32,
+    /// Quality rating.
+    pub quality_rating: String,
+    /// Drift percentage on largest size (0.0 if not detected).
+    pub drift_pct: f64,
+    /// Lag-1 autocorrelation on largest size.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autocorr_r: Option<f64>,
+    /// Effective sample size (Kish's formula).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ess: Option<f64>,
+}
+
+/// Latency stats for a specific allocation size.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SizeStats {
+    pub size: u64,
+    pub latency: LatencyStats,
+}
+
 /// Result of ordinary least-squares linear regression: `y = intercept + slope * x`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LinearFit {
@@ -737,7 +769,7 @@ fn human_size(bytes: u64) -> String {
 }
 
 /// Run all stage 3 performance tests.
-/// Returns sub-test results (and the first error, if any).
+/// Returns sub-test results, the first error (if any), and analysis JSON.
 #[allow(clippy::cast_possible_truncation)]
 pub fn run<B: HeapBackend + DmaBufBackend>(
     backend: &B,
@@ -746,7 +778,11 @@ pub fn run<B: HeapBackend + DmaBufBackend>(
     iterations: u32,
     warmup: u32,
     heap_w: usize,
-) -> (Vec<SubTestResult>, Option<anyhow::Error>) {
+) -> (
+    Vec<SubTestResult>,
+    Option<anyhow::Error>,
+    Option<PerfAnalysis>,
+) {
     let sizes = sizes.unwrap_or(DEFAULT_SIZES);
 
     tracing::debug!(
@@ -759,12 +795,12 @@ pub fn run<B: HeapBackend + DmaBufBackend>(
 
     let caps = crate::probe::probe_heap(backend, heap_name);
 
+    // Run bench_alloc_only separately to capture PerfAnalysis.
+    let alloc_result = bench_alloc_only(backend, heap_name, sizes, iterations, warmup, heap_w);
+    let analysis = alloc_result.as_ref().ok().cloned();
+
     let tests: Vec<(&str, nix::Result<()>, bool)> = vec![
-        (
-            "bench_alloc_only",
-            bench_alloc_only(backend, heap_name, sizes, iterations, warmup, heap_w),
-            false,
-        ),
+        ("bench_alloc_only", alloc_result.map(|_| ()), false),
         (
             "bench_full_pipeline",
             if caps.can_mmap {
@@ -801,10 +837,12 @@ pub fn run<B: HeapBackend + DmaBufBackend>(
         ),
     ];
 
-    runner::collect_test_results("perf", heap_name, heap_w, &tests)
+    let (sub, err) = runner::collect_test_results("perf", heap_name, heap_w, &tests);
+    (sub, err, analysis)
 }
 
 /// Benchmark alloc-only latency (ioctl call to fd return).
+/// Returns `PerfAnalysis` with all computed diagnostics for JSON output.
 #[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
 fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
     backend: &B,
@@ -813,7 +851,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
     iterations: u32,
     warmup: u32,
     heap_w: usize,
-) -> nix::Result<()> {
+) -> nix::Result<PerfAnalysis> {
     let heap = DmaHeap::open(backend, heap_name)?;
     let mut rows: Vec<Vec<String>> = Vec::new();
     let mut regression_points: Vec<(u64, u64)> = Vec::new();
@@ -1006,7 +1044,28 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         }
     }
 
-    Ok(())
+    // Build PerfAnalysis for JSON output.
+    let size_stats: Vec<SizeStats> = sizes
+        .iter()
+        .zip(all_stats.iter())
+        .map(|(&s, st)| SizeStats {
+            size: s,
+            latency: st.clone(),
+        })
+        .collect();
+    let regression = linear_regression(&regression_points);
+    let (ac_r, ac_ess) =
+        autocorrelation(&last_samples).map_or((None, None), |(r, e)| (Some(r), Some(e)));
+
+    Ok(PerfAnalysis {
+        stats: size_stats,
+        regression,
+        quality_score: qc.total,
+        quality_rating: qc.rating.to_string(),
+        drift_pct,
+        autocorr_r: ac_r,
+        ess: ac_ess,
+    })
 }
 
 /// Score a metric value against thresholds, returning (score, optional recommendation).
@@ -2347,9 +2406,13 @@ mod tests {
     #[test]
     fn run_passes() {
         let b = MockBackend::new();
-        let (results, err) = run(&b, "system", Some(&[4096]), 5, 1, 6);
+        let (results, err, analysis) = run(&b, "system", Some(&[4096]), 5, 1, 6);
         assert!(err.is_none());
         assert!(results.iter().all(|t| t.passed));
         assert_eq!(results.len(), 7);
+        let a = analysis.unwrap();
+        assert_eq!(a.stats.len(), 1);
+        assert_eq!(a.stats[0].size, 4096);
+        assert!(a.quality_score > 0);
     }
 }

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -166,6 +166,103 @@ pub(crate) fn percentile_ci(sorted: &[u64], p: u32) -> (u64, u64) {
     (sorted[lower_rank - 1], sorted[upper_rank - 1])
 }
 
+/// Result of bimodal distribution detection.
+pub(crate) struct BimodalInfo {
+    /// Center of the lower mode (bucket midpoint).
+    pub mode1_center: u64,
+    /// Center of the upper mode (bucket midpoint).
+    pub mode2_center: u64,
+    /// Fraction of samples in the lower mode (0.0–1.0).
+    pub mode1_frac: f64,
+    /// Valley depth ratio: `valley_count / min(peak1, peak2)`. Lower = deeper split.
+    pub valley_ratio: f64,
+}
+
+/// Detect bimodal distribution in sorted latency samples.
+///
+/// Uses histogram peak detection: builds equal-width buckets, finds local
+/// maxima (peaks higher than both neighbors), and checks for a significant
+/// valley between the two highest peaks.
+///
+/// Returns `Some` if two distinct modes are found with a valley depth
+/// < 50% of the smaller peak. Requires >= 20 samples.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+pub(crate) fn detect_bimodal(sorted: &[u64]) -> Option<BimodalInfo> {
+    let n = sorted.len();
+    if n < 20 {
+        return None;
+    }
+
+    let min_val = sorted[0];
+    let max_val = sorted[n - 1];
+    if min_val == max_val {
+        return None; // uniform
+    }
+
+    // Sturges' rule for bucket count, minimum 8 for bimodal resolution.
+    let k = ((n as f64).log2().ceil() as usize + 1).max(8);
+    let range = max_val - min_val;
+    let width = (range / k as u64).max(1);
+
+    // Build histogram.
+    let mut counts = vec![0usize; k];
+    for &v in sorted {
+        let idx = ((v - min_val) / width) as usize;
+        counts[idx.min(k - 1)] += 1;
+    }
+
+    // Find local maxima (peaks): count[i] > count[i-1] AND count[i] > count[i+1].
+    let mut peaks: Vec<(usize, usize)> = Vec::new(); // (bucket_index, count)
+    for i in 0..k {
+        let left = if i > 0 { counts[i - 1] } else { 0 };
+        let right = if i + 1 < k { counts[i + 1] } else { 0 };
+        if counts[i] > left && counts[i] > right {
+            peaks.push((i, counts[i]));
+        }
+    }
+
+    if peaks.len() < 2 {
+        return None; // unimodal
+    }
+
+    // Sort peaks by count (descending) and take top 2.
+    peaks.sort_by(|a, b| b.1.cmp(&a.1));
+    let (idx1, cnt1) = peaks[0];
+    let (idx2, cnt2) = peaks[1];
+    let (lo_idx, hi_idx) = if idx1 < idx2 {
+        (idx1, idx2)
+    } else {
+        (idx2, idx1)
+    };
+
+    // Find the valley (minimum count) between the two peaks.
+    let valley_count = counts[lo_idx..=hi_idx].iter().copied().min().unwrap_or(0);
+    let smaller_peak = cnt1.min(cnt2);
+    if smaller_peak == 0 {
+        return None;
+    }
+
+    let valley_ratio = valley_count as f64 / smaller_peak as f64;
+    if valley_ratio >= 0.5 {
+        return None; // valley not deep enough
+    }
+
+    // Count samples in mode 1 (up to midpoint between peaks).
+    let split_idx = usize::midpoint(lo_idx, hi_idx);
+    let mode1_count: usize = counts[..=split_idx].iter().sum();
+
+    Some(BimodalInfo {
+        mode1_center: min_val + lo_idx as u64 * width + width / 2,
+        mode2_center: min_val + hi_idx as u64 * width + width / 2,
+        mode1_frac: mode1_count as f64 / n as f64,
+        valley_ratio: (valley_ratio * 100.0).round() / 100.0,
+    })
+}
+
 /// Compute trimmed mean by removing IQR outliers from a sorted slice.
 ///
 /// Uses Tukey's fence: outliers are values outside `[Q1 - 1.5*IQR, Q3 + 1.5*IQR]`.
@@ -652,6 +749,22 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
             let mut sorted = samples.clone();
             sorted.sort_unstable();
             let (p99_lo, p99_hi) = percentile_ci(&sorted, 99);
+
+            // Bimodal detection (pool hit vs buddy alloc).
+            if let Some(bm) = detect_bimodal(&sorted) {
+                #[allow(clippy::cast_precision_loss)]
+                let pct1 = (bm.mode1_frac * 100.0).round();
+                crate::fmt::print_metric(
+                    heap_name,
+                    heap_w,
+                    &format!("perf::bimodal@{}", human_size(size)),
+                    &[
+                        ("fast", &format!("{}us ({pct1:.0}%)", bm.mode1_center)),
+                        ("slow", &format!("{}us", bm.mode2_center)),
+                        ("valley", &format!("{:.0}%", bm.valley_ratio * 100.0)),
+                    ],
+                );
+            }
 
             regression_points.push((size, stats.avg_us));
             all_stats.push(stats.clone());
@@ -1494,6 +1607,50 @@ mod tests {
             width50 >= width99,
             "p50 CI ({width50}) should be ≥ p99 CI ({width99})"
         );
+    }
+
+    // ── bimodal detection tests ──
+
+    #[test]
+    fn bimodal_too_few() {
+        let sorted: Vec<u64> = (1..=10).collect();
+        assert!(detect_bimodal(&sorted).is_none());
+    }
+
+    #[test]
+    fn bimodal_uniform() {
+        let sorted = vec![50u64; 30];
+        assert!(detect_bimodal(&sorted).is_none());
+    }
+
+    #[test]
+    fn bimodal_unimodal() {
+        // Normal-ish distribution: single peak.
+        let sorted: Vec<u64> = (1..=100).collect();
+        // Uniform distribution has no peaks — should be None or unimodal.
+        assert!(detect_bimodal(&sorted).is_none());
+    }
+
+    #[test]
+    fn bimodal_clear_two_modes() {
+        // 30 samples at ~10, 30 samples at ~100 — clear bimodal.
+        let mut sorted = vec![10u64; 30];
+        sorted.extend(vec![100u64; 30]);
+        sorted.sort_unstable();
+        let bm = detect_bimodal(&sorted);
+        assert!(bm.is_some(), "should detect bimodal distribution");
+        let bm = bm.unwrap();
+        assert!(
+            bm.mode1_center < 50,
+            "mode1 should be near 10: {}",
+            bm.mode1_center
+        );
+        assert!(
+            bm.mode2_center > 50,
+            "mode2 should be near 100: {}",
+            bm.mode2_center
+        );
+        assert!(bm.valley_ratio < 0.5, "valley should be deep");
     }
 
     // ── quality scorecard tests ──

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -10,6 +10,7 @@ use crate::dmabuf::DmaBuf;
 use crate::heap::DmaHeap;
 use crate::ioctl::dma_buf::{DMA_BUF_SYNC_READ, DMA_BUF_SYNC_WRITE};
 use crate::ioctl::dma_heap::{DMA_HEAP_ALLOC_FD_FLAGS, DMA_HEAP_VALID_HEAP_FLAGS};
+use crate::probe::align_to;
 use crate::runner::{self, SubTestResult};
 
 /// Default sizes for performance measurement.
@@ -483,8 +484,6 @@ fn warmup_sufficient(samples: &[u64]) -> bool {
     // If Welch's test finds significant difference → warmup insufficient.
     welch_test(head, tail).is_none_or(|w| w.sig == "ns")
 }
-
-use crate::probe::align_to;
 
 /// Format throughput as Kops/s (thousands of operations per second).
 fn format_throughput(ops: u64) -> String {
@@ -1066,8 +1065,15 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         &rows,
     );
 
+    // Pre-compute expensive analyses once for reuse in display + JSON.
+    let regression = linear_regression(&regression_points);
+    let drift_info = detect_drift(&last_samples);
+    let ac_info = autocorrelation(&last_samples);
+    let mut last_sorted = last_samples.clone();
+    last_sorted.sort_unstable();
+
     // Size-latency regression: latency_us = base + slope * size_bytes
-    if let Some(fit) = linear_regression(&regression_points) {
+    if let Some(ref fit) = regression {
         crate::fmt::print_metric(
             heap_name,
             heap_w,
@@ -1130,12 +1136,8 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         );
     }
 
-    // Shannon entropy: predictability of latency distribution.
-    if let Some(entropy) = latency_entropy(&{
-        let mut s = last_samples.clone();
-        s.sort_unstable();
-        s
-    }) {
+    // Shannon entropy: predictability of latency distribution (uses pre-sorted data).
+    if let Some(entropy) = latency_entropy(&last_sorted) {
         let label = match () {
             () if entropy < 0.3 => "deterministic",
             () if entropy < 0.7 => "moderate",
@@ -1150,7 +1152,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
     }
 
     // Drift detection on the last (largest) size — most sensitive to thermal/pressure effects.
-    if let Some(drift) = detect_drift(&last_samples).filter(|d| d.drift_pct.abs() > 10.0) {
+    if let Some(drift) = drift_info.as_ref().filter(|d| d.drift_pct.abs() > 10.0) {
         let direction = if drift.drift_pct > 0.0 {
             "degrading"
         } else {
@@ -1180,7 +1182,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
     }
 
     // Autocorrelation check on last (largest) size — detects non-independence.
-    if let Some((r, ess)) = autocorrelation(&last_samples).filter(|&(r, _)| r.abs() > 0.1) {
+    if let Some((r, ess)) = ac_info.filter(|(r, _)| r.abs() > 0.1) {
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let ess_int = ess.round() as u64;
         crate::fmt::print_metric(
@@ -1222,8 +1224,8 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         }
     }
 
-    // Quality scorecard: aggregate all diagnostic signals.
-    let drift_pct = detect_drift(&last_samples).map_or(0.0, |d| d.drift_pct);
+    // Quality scorecard: aggregate all diagnostic signals (reuse cached drift_info).
+    let drift_pct = drift_info.as_ref().map_or(0.0, |d| d.drift_pct);
     let stat_refs: Vec<&LatencyStats> = all_stats.iter().collect();
     let qc = quality_scorecard(&stat_refs, drift_pct, warmup_ok);
     crate::fmt::print_metric(
@@ -1255,13 +1257,11 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
             latency: st.clone(),
         })
         .collect();
-    let regression = linear_regression(&regression_points);
-    let (ac_r, ac_ess) =
-        autocorrelation(&last_samples).map_or((None, None), |(r, e)| (Some(r), Some(e)));
+    let (ac_r, ac_ess) = ac_info.map_or((None, None), |(r, e)| (Some(r), Some(e)));
 
     Ok(PerfAnalysis {
         stats: size_stats,
-        regression,
+        regression: regression.clone(),
         quality_score: qc.total,
         quality_rating: qc.rating.to_string(),
         drift_pct,

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -359,6 +359,52 @@ fn iqr_trimmed_mean(sorted: &[u64], raw_mean: f64) -> (u64, usize) {
     (trimmed_avg, n - kept)
 }
 
+/// Compute skewness (3rd moment) and excess kurtosis (4th moment - 3).
+///
+/// - Skewness > 0: right-tailed (common for latency). Higher = longer tail.
+/// - Kurtosis > 0 (leptokurtic): heavier tails than normal.
+/// - Kurtosis < 0 (platykurtic): lighter tails than normal.
+///
+/// Returns `None` if fewer than 4 samples or zero variance.
+#[allow(clippy::cast_precision_loss)]
+fn distribution_shape(samples: &[u64]) -> Option<(f64, f64)> {
+    let n = samples.len();
+    if n < 4 {
+        return None;
+    }
+
+    let mean: f64 = samples.iter().map(|&v| v as f64).sum::<f64>() / n as f64;
+    let m2: f64 = samples
+        .iter()
+        .map(|&v| (v as f64 - mean).powi(2))
+        .sum::<f64>()
+        / n as f64;
+
+    if m2 == 0.0 {
+        return None;
+    }
+
+    let sd = m2.sqrt();
+    let m3: f64 = samples
+        .iter()
+        .map(|&v| (v as f64 - mean).powi(3))
+        .sum::<f64>()
+        / n as f64;
+    let m4: f64 = samples
+        .iter()
+        .map(|&v| (v as f64 - mean).powi(4))
+        .sum::<f64>()
+        / n as f64;
+
+    let skewness = m3 / sd.powi(3);
+    let kurtosis = m4 / sd.powi(4) - 3.0; // excess kurtosis
+
+    Some((
+        (skewness * 100.0).round() / 100.0,
+        (kurtosis * 100.0).round() / 100.0,
+    ))
+}
+
 /// Test whether warmup was sufficient by comparing the first 10% of
 /// **time-ordered** measurement samples against the remaining 90%.
 ///
@@ -1004,6 +1050,26 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
                 &scaling_rows,
             );
         }
+    }
+
+    // Distribution shape of last (largest) size.
+    if let Some((skew, kurt)) = distribution_shape(&last_samples) {
+        let tail = match () {
+            () if skew > 2.0 => "heavy right tail",
+            () if skew > 0.5 => "right-skewed",
+            () if skew < -0.5 => "left-skewed",
+            () => "symmetric",
+        };
+        crate::fmt::print_metric(
+            heap_name,
+            heap_w,
+            "perf::distribution",
+            &[
+                ("skew", &format!("{skew:.2}")),
+                ("kurtosis", &format!("{kurt:.2}")),
+                ("shape", &tail),
+            ],
+        );
     }
 
     // Drift detection on the last (largest) size — most sensitive to thermal/pressure effects.
@@ -1904,6 +1970,31 @@ mod tests {
         let (r, ess) = autocorrelation(&samples).unwrap();
         assert!(r > 0.5, "monotonic should have high r: {r}");
         assert!(ess < 50.0, "ESS should be much less than N=100: {ess}");
+    }
+
+    // ── distribution shape tests ──
+
+    #[test]
+    fn shape_symmetric() {
+        // Uniform 1..=100: symmetric, skewness ≈ 0.
+        let samples: Vec<u64> = (1..=100).collect();
+        let (skew, _kurt) = distribution_shape(&samples).unwrap();
+        assert!(skew.abs() < 0.1, "uniform should be symmetric: skew={skew}");
+    }
+
+    #[test]
+    fn shape_right_skewed() {
+        // 90 values at 10, 10 values at 1000: right-skewed.
+        let mut samples = vec![10u64; 90];
+        samples.extend(vec![1000u64; 10]);
+        let (skew, kurt) = distribution_shape(&samples).unwrap();
+        assert!(skew > 1.0, "should be right-skewed: skew={skew}");
+        assert!(kurt > 0.0, "should be leptokurtic: kurt={kurt}");
+    }
+
+    #[test]
+    fn shape_too_few() {
+        assert!(distribution_shape(&[1, 2, 3]).is_none());
     }
 
     // ── percentile CI tests ──

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -48,6 +48,9 @@ pub struct LatencyStats {
     /// 95% confidence interval half-width: 1.96 * stddev / sqrt(n).
     /// True mean lies within [avg - ci95, avg + ci95] with 95% probability.
     pub ci95_us: u64,
+    /// Median Absolute Deviation: `median(|x_i - median|)`.
+    /// Robust dispersion measure (breakdown point 50% vs stddev's 0%).
+    pub mad_us: u64,
 }
 
 /// Compute latency statistics from a slice of microsecond measurements.
@@ -103,6 +106,18 @@ pub fn compute_stats(samples: &[u64]) -> Option<LatencyStats> {
     // 95% CI half-width: 1.96 * stddev / sqrt(n)
     let ci95 = (1.96 * stddev / (count as f64).sqrt()).ceil() as u64;
 
+    // MAD: median(|x_i - median|)
+    let median = sorted[count / 2] as f64;
+    let mut abs_devs: Vec<u64> = sorted
+        .iter()
+        .map(|&x| {
+            let dev = (x as f64 - median).abs();
+            dev.round() as u64
+        })
+        .collect();
+    abs_devs.sort_unstable();
+    let mad = abs_devs[abs_devs.len() / 2];
+
     Some(LatencyStats {
         count,
         min_us: sorted[0],
@@ -118,6 +133,7 @@ pub fn compute_stats(samples: &[u64]) -> Option<LatencyStats> {
         outlier_count,
         throughput_ops: throughput,
         ci95_us: ci95,
+        mad_us: mad,
     })
 }
 
@@ -1664,6 +1680,7 @@ mod tests {
         assert_eq!(stats.throughput_ops, 23810);
         // ci95: 1.96 * 0 / 1 = 0
         assert_eq!(stats.ci95_us, 0);
+        assert_eq!(stats.mad_us, 0);
     }
 
     #[test]
@@ -1686,6 +1703,9 @@ mod tests {
         assert_eq!(stats.ci95_us, 6);
         // throughput: 1e6/50.5 ≈ 19802
         assert_eq!(stats.throughput_ops, 19802);
+        // MAD of 1..=100: median=50, |x-50| sorted → 0,1,1,2,2,...,49,50
+        // median of deviations = 25
+        assert_eq!(stats.mad_us, 25);
     }
 
     #[test]
@@ -1695,6 +1715,28 @@ mod tests {
         assert_eq!(stats.min_us, 1);
         assert_eq!(stats.max_us, 100);
         assert_eq!(stats.p50_us, 50);
+    }
+
+    // ── MAD tests ──
+
+    #[test]
+    fn mad_uniform_is_zero() {
+        let stats = compute_stats(&[50; 20]).unwrap();
+        assert_eq!(stats.mad_us, 0);
+    }
+
+    #[test]
+    fn mad_with_outlier_robust() {
+        // 19x value 10, 1x outlier 1000. Median=10, |x-10| for non-outlier=0.
+        // MAD should remain 0 (robust against single outlier).
+        let mut samples = vec![10u64; 19];
+        samples.push(1000);
+        let stats = compute_stats(&samples).unwrap();
+        assert_eq!(
+            stats.mad_us, 0,
+            "MAD should be robust against single outlier"
+        );
+        assert!(stats.stddev_us > 0, "stddev should be inflated by outlier");
     }
 
     #[test]
@@ -1845,6 +1887,7 @@ mod tests {
             outlier_count: 0,
             throughput_ops: 90909,
             ci95_us: 0,
+            mad_us: 0,
         };
         let qc = quality_scorecard(&[&stats], 0.0);
         assert_eq!(qc.rating, "EXCELLENT");
@@ -1870,6 +1913,7 @@ mod tests {
             outlier_count: 30,
             throughput_ops: 20000,
             ci95_us: 40,
+            mad_us: 100,
         };
         let qc = quality_scorecard(&[&stats], 50.0);
         assert_eq!(qc.rating, "NOISY");

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -43,6 +43,11 @@ pub struct LatencyStats {
     pub trimmed_avg_us: u64,
     /// Number of samples identified as outliers by IQR method.
     pub outlier_count: usize,
+    /// Throughput in operations per second (`1e6 / mean_us`). 0 if mean is 0.
+    pub throughput_ops: u64,
+    /// 95% confidence interval half-width: 1.96 * stddev / sqrt(n).
+    /// True mean lies within [avg - ci95, avg + ci95] with 95% probability.
+    pub ci95_us: u64,
 }
 
 /// Compute latency statistics from a slice of microsecond measurements.
@@ -88,6 +93,16 @@ pub fn compute_stats(samples: &[u64]) -> Option<LatencyStats> {
     // IQR outlier detection: fence = [Q1 - 1.5*IQR, Q3 + 1.5*IQR]
     let (trimmed_avg, outlier_count) = iqr_trimmed_mean(&sorted, mean_f);
 
+    // Throughput: ops/sec = 1e6 / mean_us
+    let throughput = if mean_f > 0.0 {
+        (1_000_000.0 / mean_f).round() as u64
+    } else {
+        0
+    };
+
+    // 95% CI half-width: 1.96 * stddev / sqrt(n)
+    let ci95 = (1.96 * stddev / (count as f64).sqrt()).ceil() as u64;
+
     Some(LatencyStats {
         count,
         min_us: sorted[0],
@@ -101,6 +116,8 @@ pub fn compute_stats(samples: &[u64]) -> Option<LatencyStats> {
         cv_pct: (cv * 10.0).round() / 10.0,
         trimmed_avg_us: trimmed_avg,
         outlier_count,
+        throughput_ops: throughput,
+        ci95_us: ci95,
     })
 }
 
@@ -162,6 +179,15 @@ fn iqr_trimmed_mean(sorted: &[u64], raw_mean: f64) -> (u64, usize) {
 }
 
 use crate::probe::align_to;
+
+/// Format throughput as Kops/s (thousands of operations per second).
+fn format_throughput(ops: u64) -> String {
+    if ops >= 1000 {
+        format!("{}", ops / 1000)
+    } else {
+        format!("0.{}", ops / 100)
+    }
+}
 
 /// Format a byte size as a human-readable string (e.g., 4096 → "4K", 1048576 → "1M").
 ///
@@ -280,7 +306,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
             rows.push(vec![
                 human_size(size),
                 stats.min_us.to_string(),
-                stats.avg_us.to_string(),
+                format!("{}±{}", stats.avg_us, stats.ci95_us),
                 stats.trimmed_avg_us.to_string(),
                 stats.stddev_us.to_string(),
                 stats.p50_us.to_string(),
@@ -288,6 +314,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
                 stats.p99_us.to_string(),
                 stats.p99_9_us.to_string(),
                 stats.max_us.to_string(),
+                format_throughput(stats.throughput_ops),
                 stats.outlier_count.to_string(),
             ]);
         }
@@ -299,7 +326,18 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         "perf::alloc_only",
         Some("(us)"),
         &[
-            "size", "min", "avg", "tavg", "sd", "p50", "p95", "p99", "p99.9", "max", "out",
+            "size",
+            "min",
+            "avg±ci95",
+            "tavg",
+            "sd",
+            "p50",
+            "p95",
+            "p99",
+            "p99.9",
+            "max",
+            "Kops/s",
+            "out",
         ],
         &rows,
     );
@@ -674,6 +712,10 @@ mod tests {
         assert_eq!(stats.p99_us, 42);
         assert_eq!(stats.p99_9_us, 42);
         assert!((stats.cv_pct - 0.0).abs() < f64::EPSILON);
+        // throughput: 1e6/42 ≈ 23809.5 → 23810
+        assert_eq!(stats.throughput_ops, 23810);
+        // ci95: 1.96 * 0 / 1 = 0
+        assert_eq!(stats.ci95_us, 0);
     }
 
     #[test]
@@ -692,6 +734,10 @@ mod tests {
         assert_eq!(stats.stddev_us, 29);
         // cv = 28.87/50.5*100 ≈ 57.2
         assert!((stats.cv_pct - 57.2).abs() < 0.1);
+        // ci95: ceil(1.96 * 28.87 / 10) = ceil(5.66) = 6
+        assert_eq!(stats.ci95_us, 6);
+        // throughput: 1e6/50.5 ≈ 19802
+        assert_eq!(stats.throughput_ops, 19802);
     }
 
     #[test]
@@ -817,6 +863,38 @@ mod tests {
         let back: LatencyStats = serde_json::from_str(&json).unwrap();
         assert_eq!(stats, back);
         assert!(back.outlier_count > 0);
+    }
+
+    // ── throughput / CI tests ──
+
+    #[test]
+    fn throughput_zero_mean() {
+        // All 0µs samples (e.g., mock backend fast path).
+        let stats = compute_stats(&[0, 0, 0, 0]).unwrap();
+        assert_eq!(stats.throughput_ops, 0);
+        assert_eq!(stats.ci95_us, 0);
+    }
+
+    #[test]
+    fn ci95_decreases_with_more_samples() {
+        // Same value distribution, more samples → tighter CI (via sqrt(n)).
+        // Use alternating 10/20 pattern so stddev is identical per sample.
+        let small: Vec<u64> = [10, 20].iter().copied().cycle().take(10).collect();
+        let large: Vec<u64> = [10, 20].iter().copied().cycle().take(100).collect();
+        let ci_small = compute_stats(&small).unwrap().ci95_us;
+        let ci_large = compute_stats(&large).unwrap().ci95_us;
+        // stddev is same (5), but sqrt(100)/sqrt(10) ≈ 3.16x → CI shrinks.
+        assert!(
+            ci_small > ci_large,
+            "CI should shrink: small={ci_small} large={ci_large}"
+        );
+    }
+
+    #[test]
+    fn format_throughput_kops() {
+        assert_eq!(format_throughput(100_000), "100");
+        assert_eq!(format_throughput(23810), "23");
+        assert_eq!(format_throughput(500), "0.5");
     }
 
     // ── bench function tests ──

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -359,6 +359,27 @@ fn iqr_trimmed_mean(sorted: &[u64], raw_mean: f64) -> (u64, usize) {
     (trimmed_avg, n - kept)
 }
 
+/// Test whether warmup was sufficient by comparing the first 10% of
+/// **time-ordered** measurement samples against the remaining 90%.
+///
+/// Uses Welch's t-test: if significantly different (p < 0.05), the first
+/// samples are still in "cold start" mode and warmup should be increased.
+/// Returns `true` if warmup appears sufficient (no significant difference).
+fn warmup_sufficient(samples: &[u64]) -> bool {
+    let n = samples.len();
+    if n < 20 {
+        return true; // too few to test
+    }
+    let split = n / 10; // first 10%
+    if split < 2 {
+        return true;
+    }
+    let head = &samples[..split];
+    let tail = &samples[split..];
+    // If Welch's test finds significant difference → warmup insufficient.
+    welch_test(head, tail).is_none_or(|w| w.sig == "ns")
+}
+
 use crate::probe::align_to;
 
 /// Format throughput as Kops/s (thousands of operations per second).
@@ -1004,6 +1025,17 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         );
     }
 
+    // Warmup sufficiency: first 10% vs rest 90% via Welch's t-test.
+    let warmup_ok = warmup_sufficient(&last_samples);
+    if !warmup_ok {
+        crate::fmt::print_metric(
+            heap_name,
+            heap_w,
+            "perf::warmup_warn",
+            &[("hint", &"first 10% differs from rest: increase --warmup")],
+        );
+    }
+
     // Autocorrelation check on last (largest) size — detects non-independence.
     if let Some((r, ess)) = autocorrelation(&last_samples).filter(|&(r, _)| r.abs() > 0.1) {
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -1023,7 +1055,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
     // Quality scorecard: aggregate all diagnostic signals.
     let drift_pct = detect_drift(&last_samples).map_or(0.0, |d| d.drift_pct);
     let stat_refs: Vec<&LatencyStats> = all_stats.iter().collect();
-    let qc = quality_scorecard(&stat_refs, drift_pct);
+    let qc = quality_scorecard(&stat_refs, drift_pct, warmup_ok);
     crate::fmt::print_metric(
         heap_name,
         heap_w,
@@ -1038,7 +1070,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
             crate::fmt::print_metric(
                 heap_name,
                 heap_w,
-                &format!("perf::quality  {dim}={score}/25"),
+                &format!("perf::quality  {dim}={score}/20"),
                 &[("hint", advice)],
             );
         }
@@ -1101,18 +1133,19 @@ struct QualityScore {
 
 /// Compute measurement quality scorecard from collected stats.
 ///
-/// Evaluates 4 dimensions (25 points each):
+/// Evaluates 5 dimensions (20 points each):
 /// - **Stability**: coefficient of variation across all sizes
 /// - **Precision**: relative confidence interval width
 /// - **Cleanliness**: outlier rate
 /// - **Stationarity**: temporal drift
+/// - **Warmup**: first 10% vs rest via Welch's t-test
 #[allow(clippy::cast_precision_loss)]
-fn quality_scorecard(all_stats: &[&LatencyStats], drift_pct: f64) -> QualityScore {
+fn quality_scorecard(all_stats: &[&LatencyStats], drift_pct: f64, warmup_ok: bool) -> QualityScore {
     // Stability: max CV across sizes.
     let max_cv = all_stats.iter().map(|s| s.cv_pct).fold(0.0_f64, f64::max);
     let (stab_score, stab_rec) = score_threshold(
         max_cv,
-        &[(5.0, 25), (10.0, 20), (20.0, 10), (30.0, 5)],
+        &[(5.0, 20), (10.0, 16), (20.0, 8), (30.0, 4)],
         0,
         &[
             (10.0, "cv>10%: increase --iterations or reduce load"),
@@ -1129,7 +1162,7 @@ fn quality_scorecard(all_stats: &[&LatencyStats], drift_pct: f64) -> QualityScor
         .fold(0.0_f64, f64::max);
     let (prec_score, prec_rec) = score_threshold(
         max_rel_ci,
-        &[(3.0, 25), (10.0, 20), (20.0, 10)],
+        &[(3.0, 20), (10.0, 16), (20.0, 8)],
         0,
         &[(10.0, "ci>10%: increase --iterations for tighter CI")],
         "ci>20%: imprecise, need significantly more iterations",
@@ -1145,7 +1178,7 @@ fn quality_scorecard(all_stats: &[&LatencyStats], drift_pct: f64) -> QualityScor
     };
     let (clean_score, clean_rec) = score_threshold(
         outlier_pct,
-        &[(1.0, 25), (5.0, 20), (10.0, 10)],
+        &[(1.0, 20), (5.0, 16), (10.0, 8)],
         0,
         &[(5.0, "outliers>5%: consider --drop-caches or isolcpus")],
         "outliers>10%: heavy interference, isolate workload",
@@ -1155,13 +1188,20 @@ fn quality_scorecard(all_stats: &[&LatencyStats], drift_pct: f64) -> QualityScor
     let abs_drift = drift_pct.abs();
     let (drift_score, drift_rec) = score_threshold(
         abs_drift,
-        &[(5.0, 25), (10.0, 15), (20.0, 5)],
+        &[(5.0, 20), (10.0, 12), (20.0, 4)],
         0,
         &[(10.0, "drift>10%: increase --warmup or shorten test")],
         "drift>20%: thermal throttling or memory pressure",
     );
 
-    let total = stab_score + prec_score + clean_score + drift_score;
+    // Warmup sufficiency: binary (pass/fail from Welch's t-test).
+    let (warm_score, warm_rec): (u32, Option<&str>) = if warmup_ok {
+        (20, None)
+    } else {
+        (0, Some("warmup insufficient: increase --warmup"))
+    };
+
+    let total = stab_score + prec_score + clean_score + drift_score + warm_score;
     let rating = match total {
         90..=100 => "EXCELLENT",
         75..=89 => "GOOD",
@@ -1174,9 +1214,10 @@ fn quality_scorecard(all_stats: &[&LatencyStats], drift_pct: f64) -> QualityScor
         ("precision", prec_score, prec_rec),
         ("cleanliness", clean_score, clean_rec),
         ("stationarity", drift_score, drift_rec),
+        ("warmup", warm_score, warm_rec),
     ];
     // Only keep items with recommendations to reduce noise.
-    details.retain(|&(_, score, _)| score < 25);
+    details.retain(|&(_, score, _)| score < 20);
 
     QualityScore {
         total,
@@ -1882,6 +1923,30 @@ mod tests {
         );
     }
 
+    // ── warmup sufficiency tests ──
+
+    #[test]
+    fn warmup_sufficient_uniform() {
+        // Uniform data: no cold start effect.
+        assert!(warmup_sufficient(&[50; 100]));
+    }
+
+    #[test]
+    fn warmup_insufficient_cold_start() {
+        // First 10% much higher than rest → warmup insufficient.
+        // Need variance within groups for Welch's test to work.
+        let mut samples: Vec<u64> = (490..=510).cycle().take(10).collect(); // cold ~500
+        let warm: Vec<u64> = (8..=12).cycle().take(90).collect(); // warm ~10
+        samples.extend(warm);
+        assert!(!warmup_sufficient(&samples));
+    }
+
+    #[test]
+    fn warmup_too_few() {
+        // < 20 samples: assume sufficient.
+        assert!(warmup_sufficient(&[1, 2, 3]));
+    }
+
     // ── bimodal detection tests ──
 
     #[test]
@@ -1948,7 +2013,7 @@ mod tests {
             ci95_us: 0,
             mad_us: 0,
         };
-        let qc = quality_scorecard(&[&stats], 0.0);
+        let qc = quality_scorecard(&[&stats], 0.0, true);
         assert_eq!(qc.rating, "EXCELLENT");
         assert!(qc.total >= 90);
         assert!(qc.details.is_empty(), "no recommendations for excellent");
@@ -1974,7 +2039,7 @@ mod tests {
             ci95_us: 40,
             mad_us: 100,
         };
-        let qc = quality_scorecard(&[&stats], 50.0);
+        let qc = quality_scorecard(&[&stats], 50.0, false);
         assert_eq!(qc.rating, "NOISY");
         assert!(qc.total < 50);
         assert!(!qc.details.is_empty(), "should have recommendations");

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -317,6 +317,82 @@ fn detect_order_steps(points: &[(u64, u64)], threshold_pct: f64) -> Vec<OrderSte
     steps
 }
 
+/// Result of Welch's t-test comparing two independent sample groups.
+struct WelchResult {
+    /// Welch's t-statistic.
+    t_stat: f64,
+    /// Cohen's d effect size: `|mean1 - mean2| / pooled_sd`.
+    cohens_d: f64,
+    /// Significance level: `"***"` (p<0.001), `"**"` (p<0.01), `"*"` (p<0.05), `"ns"`.
+    sig: &'static str,
+    /// Human-readable effect magnitude.
+    effect: &'static str,
+}
+
+/// Welch's t-test for unequal variances + Cohen's d effect size.
+///
+/// Compares two sample groups and reports statistical significance and practical
+/// effect size. Uses normal approximation for p-value (valid for n > 30).
+///
+/// Returns `None` if either group has fewer than 2 samples or zero variance.
+#[allow(clippy::cast_precision_loss)]
+fn welch_test(a: &[u64], b: &[u64]) -> Option<WelchResult> {
+    if a.len() < 2 || b.len() < 2 {
+        return None;
+    }
+
+    let n1 = a.len() as f64;
+    let n2 = b.len() as f64;
+    let mean1: f64 = a.iter().map(|&v| v as f64).sum::<f64>() / n1;
+    let mean2: f64 = b.iter().map(|&v| v as f64).sum::<f64>() / n2;
+    let var1: f64 = a.iter().map(|&v| (v as f64 - mean1).powi(2)).sum::<f64>() / (n1 - 1.0);
+    let var2: f64 = b.iter().map(|&v| (v as f64 - mean2).powi(2)).sum::<f64>() / (n2 - 1.0);
+
+    let se = (var1 / n1 + var2 / n2).sqrt();
+    if se == 0.0 {
+        return None;
+    }
+
+    let t_stat = (mean1 - mean2) / se;
+
+    // Cohen's d: pooled SD from both groups.
+    let pooled_var = f64::midpoint(var1, var2);
+    let cohens_d = if pooled_var > 0.0 {
+        (mean1 - mean2).abs() / pooled_var.sqrt()
+    } else {
+        0.0
+    };
+
+    // Normal approximation significance thresholds (valid for df > 30).
+    let abs_t = t_stat.abs();
+    let sig = if abs_t > 3.291 {
+        "***"
+    } else if abs_t > 2.576 {
+        "**"
+    } else if abs_t > 1.960 {
+        "*"
+    } else {
+        "ns"
+    };
+
+    let effect = if cohens_d < 0.2 {
+        "negligible"
+    } else if cohens_d < 0.5 {
+        "small"
+    } else if cohens_d < 0.8 {
+        "medium"
+    } else {
+        "large"
+    };
+
+    Some(WelchResult {
+        t_stat: (t_stat * 100.0).round() / 100.0,
+        cohens_d: (cohens_d * 100.0).round() / 100.0,
+        sig,
+        effect,
+    })
+}
+
 /// Result of ordinary least-squares linear regression: `y = intercept + slope * x`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LinearFit {
@@ -840,6 +916,21 @@ fn bench_pool_warmup<B: HeapBackend + DmaBufBackend>(
                 ("warm_p95", &warm.p95_us),
             ],
         );
+
+        // Welch's t-test: is the cold/warm difference statistically significant?
+        if let Some(w) = welch_test(&cold_samples, &warm_samples) {
+            crate::fmt::print_metric(
+                heap_name,
+                heap_w,
+                "perf::pool_effect",
+                &[
+                    ("t", &format!("{:.2}", w.t_stat)),
+                    ("d", &format!("{:.2}", w.cohens_d)),
+                    ("sig", &w.sig),
+                    ("effect", &w.effect),
+                ],
+            );
+        }
     }
 
     Ok(())
@@ -1142,6 +1233,48 @@ mod tests {
             ci_small > ci_large,
             "CI should shrink: small={ci_small} large={ci_large}"
         );
+    }
+
+    // ── Welch's t-test tests ──
+
+    #[test]
+    fn welch_too_few() {
+        assert!(welch_test(&[1], &[2, 3]).is_none());
+        assert!(welch_test(&[1, 2], &[3]).is_none());
+    }
+
+    #[test]
+    fn welch_identical_groups() {
+        let a = vec![100; 20];
+        let b = vec![100; 20];
+        // Zero variance → None (can't compute SE).
+        assert!(welch_test(&a, &b).is_none());
+    }
+
+    #[test]
+    fn welch_significant_difference() {
+        // Group A: mean=10, Group B: mean=100 — clearly different.
+        let a: Vec<u64> = (5..=15).collect();
+        let b: Vec<u64> = (95..=105).collect();
+        let w = welch_test(&a, &b).unwrap();
+        assert!(
+            w.t_stat < -10.0,
+            "t should be strongly negative: {}",
+            w.t_stat
+        );
+        assert_eq!(w.sig, "***");
+        assert_eq!(w.effect, "large");
+        assert!(w.cohens_d > 0.8);
+    }
+
+    #[test]
+    fn welch_not_significant() {
+        // Nearly identical distributions — not significant.
+        let a: Vec<u64> = vec![10, 11, 10, 11, 10, 11, 10, 11, 10, 11];
+        let b: Vec<u64> = vec![10, 11, 10, 11, 10, 11, 10, 11, 11, 10];
+        let w = welch_test(&a, &b).unwrap();
+        assert_eq!(w.sig, "ns");
+        assert_eq!(w.effect, "negligible");
     }
 
     #[test]

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -263,6 +263,45 @@ pub(crate) fn detect_bimodal(sorted: &[u64]) -> Option<BimodalInfo> {
     })
 }
 
+/// Compute lag-1 autocorrelation and effective sample size from **time-ordered** samples.
+///
+/// Lag-1 autocorrelation `r = cov(x[i], x[i+1]) / var(x)` measures how much
+/// each sample predicts the next. High `r` (pool caching, thermal effects) means
+/// consecutive samples are not independent, inflating CI precision.
+///
+/// Effective sample size: `ESS = N × (1 - r) / (1 + r)` (Kish's formula).
+/// Returns `None` if fewer than 3 samples or zero variance.
+#[allow(clippy::cast_precision_loss)]
+fn autocorrelation(samples: &[u64]) -> Option<(f64, f64)> {
+    let n = samples.len();
+    if n < 3 {
+        return None;
+    }
+
+    let mean: f64 = samples.iter().map(|&v| v as f64).sum::<f64>() / n as f64;
+    let var: f64 = samples
+        .iter()
+        .map(|&v| (v as f64 - mean).powi(2))
+        .sum::<f64>();
+    if var == 0.0 {
+        return None;
+    }
+
+    // Lag-1 autocovariance (unnormalized).
+    let autocov: f64 = samples
+        .windows(2)
+        .map(|w| (w[0] as f64 - mean) * (w[1] as f64 - mean))
+        .sum();
+
+    let r = autocov / var; // normalized: autocov / var = autocorrelation
+    let r_clamped = r.clamp(-0.99, 0.99); // avoid division by zero in ESS
+
+    let ess = n as f64 * (1.0 - r_clamped) / (1.0 + r_clamped);
+    let r_rounded = (r * 1000.0).round() / 1000.0;
+
+    Some((r_rounded, ess.max(1.0)))
+}
+
 /// Compute trimmed mean by removing IQR outliers from a sorted slice.
 ///
 /// Uses Tukey's fence: outliers are values outside `[Q1 - 1.5*IQR, Q3 + 1.5*IQR]`.
@@ -867,6 +906,22 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
                 ("drift", &format!("{:+.1}%", drift.drift_pct)),
                 ("1st_half", &drift.first_half_avg_us),
                 ("2nd_half", &drift.second_half_avg_us),
+            ],
+        );
+    }
+
+    // Autocorrelation check on last (largest) size — detects non-independence.
+    if let Some((r, ess)) = autocorrelation(&last_samples).filter(|&(r, _)| r.abs() > 0.1) {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let ess_int = ess.round() as u64;
+        crate::fmt::print_metric(
+            heap_name,
+            heap_w,
+            "perf::autocorr",
+            &[
+                ("lag1_r", &format!("{r:.3}")),
+                ("N", &last_samples.len()),
+                ("ESS", &ess_int),
             ],
         );
     }
@@ -1593,6 +1648,38 @@ mod tests {
         let json = serde_json::to_string(&stats).unwrap();
         let deserialized: LatencyStats = serde_json::from_str(&json).unwrap();
         assert_eq!(stats, deserialized);
+    }
+
+    // ── autocorrelation tests ──
+
+    #[test]
+    fn autocorr_too_few() {
+        assert!(autocorrelation(&[1, 2]).is_none());
+    }
+
+    #[test]
+    fn autocorr_zero_variance() {
+        assert!(autocorrelation(&[5, 5, 5, 5]).is_none());
+    }
+
+    #[test]
+    fn autocorr_independent_samples() {
+        // Alternating pattern: no positive autocorrelation.
+        let samples: Vec<u64> = [10, 20].iter().copied().cycle().take(100).collect();
+        let (r, ess) = autocorrelation(&samples).unwrap();
+        // Alternating → negative autocorrelation (r ≈ -1).
+        assert!(r < 0.0, "alternating should have negative r: {r}");
+        // ESS > N for negatively correlated samples.
+        assert!(ess > 100.0, "ESS should exceed N for negative r: {ess}");
+    }
+
+    #[test]
+    fn autocorr_strongly_correlated() {
+        // Monotonically increasing → strong positive autocorrelation.
+        let samples: Vec<u64> = (1..=100).collect();
+        let (r, ess) = autocorrelation(&samples).unwrap();
+        assert!(r > 0.5, "monotonic should have high r: {r}");
+        assert!(ess < 50.0, "ESS should be much less than N=100: {ess}");
     }
 
     // ── percentile CI tests ──

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -822,6 +822,36 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         );
     }
 
+    // Throughput scaling efficiency: how well does throughput hold as size grows?
+    if all_stats.len() >= 2 {
+        let base_tp = all_stats[0].throughput_ops;
+        if base_tp > 0 {
+            let mut scaling_rows: Vec<Vec<String>> = Vec::new();
+            for (i, stats) in all_stats.iter().enumerate() {
+                #[allow(clippy::cast_precision_loss)]
+                let efficiency = stats.throughput_ops as f64 / base_tp as f64 * 100.0;
+                let size = sizes[i];
+                // Bandwidth: throughput * size = bytes/sec.
+                #[allow(clippy::cast_precision_loss)]
+                let bw_mb = stats.throughput_ops as f64 * size as f64 / 1_048_576.0;
+                scaling_rows.push(vec![
+                    human_size(size),
+                    format_throughput(stats.throughput_ops),
+                    format!("{efficiency:.1}"),
+                    format!("{bw_mb:.0}"),
+                ]);
+            }
+            crate::fmt::print_table(
+                heap_name,
+                heap_w,
+                "perf::scaling",
+                None,
+                &["size", "Kops/s", "eff%", "MB/s"],
+                &scaling_rows,
+            );
+        }
+    }
+
     // Drift detection on the last (largest) size — most sensitive to thermal/pressure effects.
     if let Some(drift) = detect_drift(&last_samples).filter(|d| d.drift_pct.abs() > 10.0) {
         let direction = if drift.drift_pct > 0.0 {

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -825,6 +825,7 @@ fn bench_close<B: HeapBackend + DmaBufBackend>(
 ) -> nix::Result<()> {
     let heap = DmaHeap::open(backend, heap_name)?;
     let mut rows: Vec<Vec<String>> = Vec::new();
+    let mut ratio_points: Vec<(u64, u64, u64)> = Vec::new();
 
     for &size in sizes {
         // Warmup
@@ -834,18 +835,24 @@ fn bench_close<B: HeapBackend + DmaBufBackend>(
             drop(buf);
         }
 
-        // Pre-alloc then measure close latency
-        let mut samples = Vec::with_capacity(iterations as usize);
+        // Paired alloc + close measurement for efficiency ratio.
+        let mut close_samples = Vec::with_capacity(iterations as usize);
+        let mut alloc_samples = Vec::with_capacity(iterations as usize);
         for _ in 0..iterations {
+            let t0 = Instant::now();
             let fd = heap.alloc(size, DMA_HEAP_ALLOC_FD_FLAGS, DMA_HEAP_VALID_HEAP_FLAGS)?;
+            let t1 = Instant::now();
             let buf = DmaBuf::new(backend, fd, size as usize);
-            let start = Instant::now();
+            let t2 = Instant::now();
             drop(buf);
-            let elapsed = start.elapsed().as_micros() as u64;
-            samples.push(elapsed);
+            let t3 = Instant::now();
+            alloc_samples.push(t1.duration_since(t0).as_micros() as u64);
+            close_samples.push(t3.duration_since(t2).as_micros() as u64);
         }
 
-        if let Some(stats) = compute_stats(&samples) {
+        if let Some(stats) = compute_stats(&close_samples) {
+            let alloc_avg = compute_stats(&alloc_samples).map_or(0, |s| s.avg_us);
+            ratio_points.push((size, alloc_avg, stats.avg_us));
             rows.push(vec![
                 human_size(size),
                 stats.avg_us.to_string(),
@@ -866,6 +873,42 @@ fn bench_close<B: HeapBackend + DmaBufBackend>(
         &["size", "avg", "sd", "p50", "p95", "p99", "p99.9"],
         &rows,
     );
+
+    // Close/alloc efficiency ratio per size.
+    if !ratio_points.is_empty() {
+        let mut ratio_rows: Vec<Vec<String>> = Vec::new();
+        for &(size, alloc_avg, close_avg) in &ratio_points {
+            #[allow(clippy::cast_precision_loss)]
+            let ratio = if alloc_avg > 0 {
+                close_avg as f64 / alloc_avg as f64
+            } else {
+                0.0
+            };
+            let label = if ratio < 0.5 {
+                "fast"
+            } else if ratio <= 2.0 {
+                "balanced"
+            } else {
+                "expensive"
+            };
+            ratio_rows.push(vec![
+                human_size(size),
+                alloc_avg.to_string(),
+                close_avg.to_string(),
+                format!("{ratio:.2}"),
+                label.to_string(),
+            ]);
+        }
+        crate::fmt::print_table(
+            heap_name,
+            heap_w,
+            "perf::close_ratio",
+            None,
+            &["size", "alloc", "close", "ratio", "verdict"],
+            &ratio_rows,
+        );
+    }
+
     Ok(())
 }
 

--- a/src/cmd/perf.rs
+++ b/src/cmd/perf.rs
@@ -613,7 +613,7 @@ pub fn run<B: HeapBackend + DmaBufBackend>(
 }
 
 /// Benchmark alloc-only latency (ioctl call to fd return).
-#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
 fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
     backend: &B,
     heap_name: &str,
@@ -626,6 +626,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
     let mut rows: Vec<Vec<String>> = Vec::new();
     let mut regression_points: Vec<(u64, u64)> = Vec::new();
     let mut last_samples: Vec<u64> = Vec::new();
+    let mut all_stats: Vec<LatencyStats> = Vec::new();
 
     for &size in sizes {
         // Warmup
@@ -653,6 +654,7 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
             let (p99_lo, p99_hi) = percentile_ci(&sorted, 99);
 
             regression_points.push((size, stats.avg_us));
+            all_stats.push(stats.clone());
             last_samples = samples;
             rows.push(vec![
                 human_size(size),
@@ -726,7 +728,148 @@ fn bench_alloc_only<B: HeapBackend + DmaBufBackend>(
         );
     }
 
+    // Quality scorecard: aggregate all diagnostic signals.
+    let drift_pct = detect_drift(&last_samples).map_or(0.0, |d| d.drift_pct);
+    let stat_refs: Vec<&LatencyStats> = all_stats.iter().collect();
+    let qc = quality_scorecard(&stat_refs, drift_pct);
+    crate::fmt::print_metric(
+        heap_name,
+        heap_w,
+        "perf::quality",
+        &[
+            ("score", &format!("{}/100", qc.total)),
+            ("rating", &qc.rating),
+        ],
+    );
+    for (dim, score, rec) in &qc.details {
+        if let Some(advice) = rec {
+            crate::fmt::print_metric(
+                heap_name,
+                heap_w,
+                &format!("perf::quality  {dim}={score}/25"),
+                &[("hint", advice)],
+            );
+        }
+    }
+
     Ok(())
+}
+
+/// Score a metric value against thresholds, returning (score, optional recommendation).
+///
+/// `thresholds` is a sorted list of `(limit, score)` — if `value < limit`, return that score.
+/// `recs` maps threshold values to recommendation strings (only for degraded scores).
+/// `fallback_rec` is used when value exceeds all thresholds.
+fn score_threshold(
+    value: f64,
+    thresholds: &[(f64, u32)],
+    floor: u32,
+    recs: &[(f64, &'static str)],
+    fallback_rec: &'static str,
+) -> (u32, Option<&'static str>) {
+    for &(limit, score) in thresholds {
+        if value < limit {
+            let rec = recs.iter().find(|&&(t, _)| value >= t).map(|&(_, r)| r);
+            return (score, rec);
+        }
+    }
+    (floor, Some(fallback_rec))
+}
+
+/// Measurement quality assessment from aggregated diagnostic signals.
+struct QualityScore {
+    /// Total score 0-100.
+    total: u32,
+    /// Rating label.
+    rating: &'static str,
+    /// Per-dimension scores and recommendations.
+    details: Vec<(&'static str, u32, Option<&'static str>)>,
+}
+
+/// Compute measurement quality scorecard from collected stats.
+///
+/// Evaluates 4 dimensions (25 points each):
+/// - **Stability**: coefficient of variation across all sizes
+/// - **Precision**: relative confidence interval width
+/// - **Cleanliness**: outlier rate
+/// - **Stationarity**: temporal drift
+#[allow(clippy::cast_precision_loss)]
+fn quality_scorecard(all_stats: &[&LatencyStats], drift_pct: f64) -> QualityScore {
+    // Stability: max CV across sizes.
+    let max_cv = all_stats.iter().map(|s| s.cv_pct).fold(0.0_f64, f64::max);
+    let (stab_score, stab_rec) = score_threshold(
+        max_cv,
+        &[(5.0, 25), (10.0, 20), (20.0, 10), (30.0, 5)],
+        0,
+        &[
+            (10.0, "cv>10%: increase --iterations or reduce load"),
+            (20.0, "cv>20%: significant noise, increase --iterations"),
+        ],
+        "cv>30%: excessive noise, check for interference",
+    );
+
+    // Precision: max relative CI (ci95/avg).
+    let max_rel_ci = all_stats
+        .iter()
+        .filter(|s| s.avg_us > 0)
+        .map(|s| s.ci95_us as f64 / s.avg_us as f64 * 100.0)
+        .fold(0.0_f64, f64::max);
+    let (prec_score, prec_rec) = score_threshold(
+        max_rel_ci,
+        &[(3.0, 25), (10.0, 20), (20.0, 10)],
+        0,
+        &[(10.0, "ci>10%: increase --iterations for tighter CI")],
+        "ci>20%: imprecise, need significantly more iterations",
+    );
+
+    // Cleanliness: total outlier rate.
+    let n_samples: usize = all_stats.iter().map(|s| s.count).sum();
+    let n_outliers: usize = all_stats.iter().map(|s| s.outlier_count).sum();
+    let outlier_pct = if n_samples > 0 {
+        n_outliers as f64 / n_samples as f64 * 100.0
+    } else {
+        0.0
+    };
+    let (clean_score, clean_rec) = score_threshold(
+        outlier_pct,
+        &[(1.0, 25), (5.0, 20), (10.0, 10)],
+        0,
+        &[(5.0, "outliers>5%: consider --drop-caches or isolcpus")],
+        "outliers>10%: heavy interference, isolate workload",
+    );
+
+    // Stationarity: drift magnitude.
+    let abs_drift = drift_pct.abs();
+    let (drift_score, drift_rec) = score_threshold(
+        abs_drift,
+        &[(5.0, 25), (10.0, 15), (20.0, 5)],
+        0,
+        &[(10.0, "drift>10%: increase --warmup or shorten test")],
+        "drift>20%: thermal throttling or memory pressure",
+    );
+
+    let total = stab_score + prec_score + clean_score + drift_score;
+    let rating = match total {
+        90..=100 => "EXCELLENT",
+        75..=89 => "GOOD",
+        50..=74 => "FAIR",
+        _ => "NOISY",
+    };
+
+    let mut details = vec![
+        ("stability", stab_score, stab_rec),
+        ("precision", prec_score, prec_rec),
+        ("cleanliness", clean_score, clean_rec),
+        ("stationarity", drift_score, drift_rec),
+    ];
+    // Only keep items with recommendations to reduce noise.
+    details.retain(|&(_, score, _)| score < 25);
+
+    QualityScore {
+        total,
+        rating,
+        details,
+    }
 }
 
 /// Pipeline stage names for breakdown analysis.
@@ -1351,6 +1494,69 @@ mod tests {
             width50 >= width99,
             "p50 CI ({width50}) should be ≥ p99 CI ({width99})"
         );
+    }
+
+    // ── quality scorecard tests ──
+
+    #[test]
+    fn scorecard_excellent() {
+        // Perfect measurements: low CV, no outliers, no drift.
+        let stats = LatencyStats {
+            count: 100,
+            min_us: 10,
+            max_us: 12,
+            avg_us: 11,
+            stddev_us: 0,
+            p50_us: 11,
+            p95_us: 12,
+            p99_us: 12,
+            p99_9_us: 12,
+            cv_pct: 1.0,
+            trimmed_avg_us: 11,
+            outlier_count: 0,
+            throughput_ops: 90909,
+            ci95_us: 0,
+        };
+        let qc = quality_scorecard(&[&stats], 0.0);
+        assert_eq!(qc.rating, "EXCELLENT");
+        assert!(qc.total >= 90);
+        assert!(qc.details.is_empty(), "no recommendations for excellent");
+    }
+
+    #[test]
+    fn scorecard_noisy() {
+        // Bad measurements: high CV, many outliers, strong drift.
+        let stats = LatencyStats {
+            count: 100,
+            min_us: 1,
+            max_us: 1000,
+            avg_us: 50,
+            stddev_us: 200,
+            p50_us: 20,
+            p95_us: 500,
+            p99_us: 900,
+            p99_9_us: 1000,
+            cv_pct: 400.0,
+            trimmed_avg_us: 20,
+            outlier_count: 30,
+            throughput_ops: 20000,
+            ci95_us: 40,
+        };
+        let qc = quality_scorecard(&[&stats], 50.0);
+        assert_eq!(qc.rating, "NOISY");
+        assert!(qc.total < 50);
+        assert!(!qc.details.is_empty(), "should have recommendations");
+    }
+
+    #[test]
+    fn score_threshold_basic() {
+        let (s, r) = score_threshold(3.0, &[(5.0, 25), (10.0, 20)], 0, &[], "bad");
+        assert_eq!(s, 25);
+        assert!(r.is_none());
+
+        let (s, r) = score_threshold(99.0, &[(5.0, 25)], 0, &[], "bad");
+        assert_eq!(s, 0);
+        assert_eq!(r, Some("bad"));
     }
 
     // ── percentile edge cases ──

--- a/src/dmabuf.rs
+++ b/src/dmabuf.rs
@@ -303,7 +303,9 @@ mod tests {
         let buf = DmaBuf::new(&backend, fd, 4096);
         let dup_buf = buf.dup().unwrap();
         let actual_size = dup_buf.llseek_size().unwrap();
-        assert_eq!(dup_buf.len() as i64, actual_size);
+        #[allow(clippy::cast_possible_wrap)]
+        let expected = dup_buf.len() as i64;
+        assert_eq!(expected, actual_size);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,16 +177,29 @@ fn dispatch_command<
             warmup,
         } => {
             let start = Instant::now();
+            let perf_analysis = std::cell::RefCell::new(None);
             let (sub, err) = run_per_heap(heaps, |h| {
-                cmd::perf::run(backend, h, sizes.as_deref(), *iterations, *warmup, heap_w)
+                let (s, e, a) =
+                    cmd::perf::run(backend, h, sizes.as_deref(), *iterations, *warmup, heap_w);
+                if perf_analysis.borrow().is_none() {
+                    *perf_analysis.borrow_mut() = a;
+                }
+                (s, e)
             });
-            Ok(Some(build_single_stage_result(
-                "perf",
-                heaps,
-                &sub,
-                err,
-                start.elapsed(),
-            )))
+            let perf_analysis = perf_analysis.into_inner();
+            let mut result = build_single_stage_result("perf", heaps, &sub, err, start.elapsed());
+            // Merge PerfAnalysis into JSON details.
+            if let (Some(analysis), Some(stage)) = (&perf_analysis, result.stages.first_mut()) {
+                let mut details = stage.details.take().unwrap_or(serde_json::json!({}));
+                if let serde_json::Value::Object(ref mut map) = details {
+                    map.insert(
+                        "analysis".to_string(),
+                        serde_json::to_value(analysis).unwrap_or_default(),
+                    );
+                }
+                stage.details = Some(details);
+            }
+            Ok(Some(result))
         }
         Command::Pressure {
             alloc_size,
@@ -394,7 +407,8 @@ fn run_all<
             stage_result(cmd::negative::run(backend, heap, heap_w))
         });
         runner::run_stage(&mut results, "perf", heap, heap_w, || {
-            stage_result(cmd::perf::run(backend, heap, None, 10, 2, heap_w))
+            let (s, e, _) = cmd::perf::run(backend, heap, None, 10, 2, heap_w);
+            stage_result((s, e))
         });
         runner::run_stage(&mut results, "pressure", heap, heap_w, || {
             stage_result(cmd::pressure::run(backend, heap, 4096, None, heap_w))


### PR DESCRIPTION
## Summary

perf 서브커맨드에 22개 통계/측정 알고리즘을 추가하여 DMA heap 할당 성능의 정량적 분석 도구를 구축.

### 추가된 알고리즘 (22개)

| # | 개선 | 핵심 알고리즘 | 적용 벤치마크 |
|---|------|-------------|-------------|
| 1 | stddev, p99.9, CV | Two-pass variance | all |
| 2 | IQR outlier detection | Tukey's 1.5×IQR fence | all |
| 3 | Throughput + 95% CI | 1e6/mean, 1.96σ/√n | alloc_only |
| 4 | Size-latency regression | OLS, R² | alloc_only |
| 5 | Drift detection | Index-latency regression | alloc_only |
| 6 | Order step detection | Adjacent-pair change | order_boundary |
| 7 | Welch's t-test + Cohen's d | t-test, effect size | pool_warmup |
| 8 | Pipeline stage breakdown | 5-point per-stage | full_pipeline |
| 9 | Hysteresis + convergence | Ratio + sliding window | size_switch |
| 10 | Close/alloc ratio | Paired timing | close |
| 11 | Percentile CI | Binomial order stats | alloc_only |
| 12 | Quality scorecard | 5-dimension scoring (0-100) | alloc_only |
| 13 | Bimodal detection | Histogram peak + valley | alloc_only |
| 14 | Scaling efficiency | Throughput retention + MB/s | alloc_only |
| 15 | Autocorrelation + ESS | Lag-1 r, Kish's formula | alloc_only |
| 16 | Order inversion | Adjacent-pair decrease | order_boundary |
| 17 | MAD | median(|x-median|) | all |
| 18 | JSON analysis output | PerfAnalysis struct | alloc_only |
| 19 | Warmup sufficiency | head/tail Welch's t-test | alloc_only |
| 20 | CI convergence | Quarter-point CI width | alloc_only |
| 21 | Skewness + kurtosis | 3rd/4th moments | alloc_only |
| 22 | Shannon entropy | Normalized H, [0-1] | alloc_only |

### 기타 변경
- `docs/MEASUREMENT.md`: 13-section 완전한 알고리즘 레퍼런스 (696줄)
- `perf.rs`: ~1500줄 추가, 79 unit tests 추가
- `/simplify` 코드 리뷰 반영: redundant computation 제거, import 정리
- clippy pedantic clean, 0 warnings

## Test plan
- [x] `cargo test --all-targets` — 436 tests pass (404 unit + 32 smoke)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo run -- perf --heaps system` — 샘플 출력 검증
- [ ] Device test on aarch64-linux-android

🤖 Generated with [Claude Code](https://claude.com/claude-code)